### PR TITLE
[Feat] Member 엔티티 및 MemberRecipe 중간 테이블 엔티티 구현

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/Member.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/Member.java
@@ -1,0 +1,37 @@
+package sejong.capston.yechef.domain.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import jakarta.persistence.Id;
+import lombok.*;
+import sejong.capston.yechef.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted is FALSE")
+public class Member extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy =  GenerationType.IDENTITY)
+  private Long id;
+
+  @NonNull
+  @Column(nullable = false)
+  private String nickname;
+
+  @NonNull
+  @Column(unique = true, nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private boolean showExamplePhoto = true;
+
+  private String oauthId;
+
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
@@ -1,0 +1,48 @@
+package sejong.capston.yechef.domain.MemberRecipe;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import sejong.capston.yechef.domain.Member.Member;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_recipe SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted IS FALSE")
+public class MemberRecipe extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long Id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "recipe_id", nullable = false)
+  private Recipe recipe;
+
+  @NonNull
+  private Boolean isLiked = false;
+
+  @NonNull
+  @Column(nullable = false)
+  private LocalDateTime savedAt;
+
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
@@ -1,6 +1,5 @@
 package sejong.capston.yechef.domain.MemberRecipe;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +26,7 @@ public class MemberRecipe extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long Id;
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
@@ -41,8 +39,8 @@ public class MemberRecipe extends BaseEntity {
   @NonNull
   private Boolean isLiked = false;
 
-  @NonNull
-  @Column(nullable = false)
-  private LocalDateTime savedAt;
+  public void toggleLike() {
+    this.isLiked = !this.isLiked;
+  }
 
 }


### PR DESCRIPTION
# 이슈
- #2 

# 구현 기능
- `Member` 엔티티 구현
- `MemberRecipe` Member-Recipe 중간 테이블 엔티티 구현
- `MemberRecipe` savedAt 필드 삭제
- `MemberRecipe` toggleLike() 메서드 구현

# 작업 시간