### PR TITLE
[refactor] 메서드 이름 member 체계로 통일 및 swagger url 시큐리티 인증 없이 접근 허가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/service/LoginService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/service/LoginService.java
@@ -27,7 +27,7 @@ public class LoginService {
         log.info("카카오 Access Token : {} ", accessToken);
 
         // 카카오 유저 정보 요청
-        KakaoResponseDto userInfo = kakaoOAuthService.getUserInfoFromToken(accessToken);
+        KakaoResponseDto userInfo = kakaoOAuthService.getMemberInfoFromToken(accessToken);
         log.info("카카오 유저 정보 : {} ", userInfo);
 
         // 로그인 or 회원가입

--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                         "/auth/**",
                         "/login",   // kakao 회원 가입 위한 외부인의 최초 접근 엔드포인트
                         "/favicon.ico", "/static/**", "/css/**", "/js/**", "/images/**",
-                        "bot/chat", "bot/chat/**"   // gpt api
+                        "bot/chat", "bot/chat/**",  // gpt api
+                        "/docs/swagger-ui/**"
                 ).permitAll()
 
                 // 관리자 전용

--- a/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtFilter.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtFilter.java
@@ -15,7 +15,6 @@ import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.domain.Member.dto.LoginMemberDto;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 @Component
 @Slf4j
@@ -42,7 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
             if (token != null && jwtProvider.validateToken(token)) {
 
-                LoginMemberDto jwtLoginMemberDto = jwtProvider.getUserDto(token);
+                LoginMemberDto jwtLoginMemberDto = jwtProvider.getMemberDto(token);
 
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                         jwtLoginMemberDto, null, jwtLoginMemberDto.getAuthorities());

--- a/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtProvider.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtProvider.java
@@ -56,15 +56,15 @@ public class JwtProvider {
     }
 
     // JWT에서 사용자 ID 추출
-    public Long getUserIdFromToken(String token) {
+    public Long getIdFromToken(String token) {
         Claims claims = parseClaims(token);
-        return claims.get("userId", Long.class);
+        return claims.get("id", Long.class);
     }
 
     //JWT에서 사용자 이름 추출
-    public String getUsernameFromToken(String token) {
+    public String getNicknameFromToken(String token) {
         Claims claims = parseClaims(token);
-        return claims.get("username", String.class);
+        return claims.get("nickname", String.class);
     }
 
     //JWT에서 사용자 권한 추출
@@ -75,10 +75,10 @@ public class JwtProvider {
     }
 
     //JWT에서 userDto 추출
-    public LoginMemberDto getUserDto(String token) {
+    public LoginMemberDto getMemberDto(String token) {
         return LoginMemberDto.fromJwt(
-                getUserIdFromToken(token),
-                getUsernameFromToken(token),
+                getIdFromToken(token),
+                getNicknameFromToken(token),
                 getRoleFromToken(token)
         );
     }

--- a/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtProvider.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/login/jwt/JwtProvider.java
@@ -30,7 +30,7 @@ public class JwtProvider {
     // JWT 생성
     public String createAccessToken(LoginMemberDto loginMemberDto) {
         Claims claims = Jwts.claims();
-        claims.put("userId", loginMemberDto.getId());
+        claims.put("memberId", loginMemberDto.getId());
         claims.put("username", loginMemberDto.getUsername());
         claims.put("role", loginMemberDto.getRole());
         return Jwts.builder()
@@ -56,9 +56,9 @@ public class JwtProvider {
     }
 
     // JWT에서 사용자 ID 추출
-    public Long getIdFromToken(String token) {
+    public Long getmemberIdFromToken(String token) {
         Claims claims = parseClaims(token);
-        return claims.get("id", Long.class);
+        return claims.get("memberId", Long.class);
     }
 
     //JWT에서 사용자 이름 추출
@@ -77,7 +77,7 @@ public class JwtProvider {
     //JWT에서 userDto 추출
     public LoginMemberDto getMemberDto(String token) {
         return LoginMemberDto.fromJwt(
-                getIdFromToken(token),
+                getmemberIdFromToken(token),
                 getNicknameFromToken(token),
                 getRoleFromToken(token)
         );

--- a/yechef/src/main/java/sejong/capston/yechef/global/login/service/KakaoOAuthService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/login/service/KakaoOAuthService.java
@@ -57,7 +57,7 @@ public class KakaoOAuthService {
         }
     }
 
-    public KakaoResponseDto getUserInfoFromToken(String accessToken) {
+    public KakaoResponseDto getMemberInfoFromToken(String accessToken) {
         String url = kakaoConfig.getUser_info_uri();
         KakaoResponseDto kakaoResponseDto = null;
 
@@ -72,11 +72,11 @@ public class KakaoOAuthService {
 
             // JSON 응답 파싱
             JsonNode root = objectMapper.readTree(response.getBody());
-            String username = root.path("properties").path("nickname").asText();
+            String nickname = root.path("properties").path("nickname").asText();
             Long oauthId = root.path("id").asLong();
 
             // 사용자 정보 저장
-            kakaoResponseDto = new KakaoResponseDto(oauthId,username);
+            kakaoResponseDto = new KakaoResponseDto(oauthId,nickname);
 
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             log.error("카카오 API 호출 실패 - 서버 오류: {}", e.getMessage());


### PR DESCRIPTION
# 이슈
- #14 

# 구현 기능
- 코드 내 메서드 및 변수 이름 일부 수정 -> **member 체계로 통일**
- SecurityConfig 에서 **swagger url** 엔드포인트 시큐리티 인증 없이 **접근 허가**

# 작업 시간
