### PR TITLE
[refactor] MemberService 예외 처리 방식 통일 및 SwaggerConfig 패키지 위치 변경

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/MemberService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/MemberService.java
@@ -4,8 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sejong.capston.yechef.domain.util.exception.CustomException;
-import sejong.capston.yechef.domain.util.exception.ErrorCode;
+import sejong.capston.yechef.domain.Member.repository.MemberRepository;
+import sejong.capston.yechef.global.exception.BaseException;
+import sejong.capston.yechef.global.exception.error.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +20,7 @@ public class MemberService {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> {
           log.error("회원 조회 실패: memberId: {}", memberId);
-          return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+          return BaseException.from(ErrorCode.MEMBER_NOT_FOUND);
         });
     log.info("회원 정보 조회 성공: userId: {}", memberId);
     return MemberDTO.builder()

--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SwaggerConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SwaggerConfig.java
@@ -1,6 +1,5 @@
-package sejong.capston.yechef.domain.util.config;
+package sejong.capston.yechef.global.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import java.util.List;

--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -9,8 +9,8 @@ public enum ErrorCode {
 
     //client error : 4xx
 
-    //user
-    USER_NOT_FOUND("USR-0000", "해당 회원이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    //member
+    MEMBER_NOT_FOUND("MEM-0000", "해당 회원이 존재하지 않습니다.", ErrorDisplayType.POPUP),
 
     //kakao Error
     KAKAO_CONFIG_MISSING("KAKAO-0000", "카카오 로그인 설정 오류 발생.", ErrorDisplayType.HIDE),


### PR DESCRIPTION
# 이슈
- 예외 처리 방식 통일 및 config 파일 패키지 위치 통일

# 구현 기능
- MemberService 에 customException-> BaseException 으로 예외 처리 통일
- ErrorCode 에 MEMBER_NOT_FOUND 추가
- Config 파일 위치 통일을 위한 SwaggerConfig 패키지 위치 변경: domain.util.config → global.config

# 작업 시간
