### PR TITLE
Feat recipe

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -41,6 +42,13 @@ public class MemberRecipe extends BaseEntity {
 
   public void toggleLike() {
     this.isLiked = !this.isLiked;
+  }
+
+  @Builder
+  public MemberRecipe(Member member, Recipe recipe) {
+    this.member = member;
+    this.recipe = recipe;
+    this.isLiked = false;
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipeRepository.java
@@ -1,0 +1,11 @@
+package sejong.capston.yechef.domain.MemberRecipe;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long> {
+
+  Optional<MemberRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
+
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -1,0 +1,54 @@
+package sejong.capston.yechef.domain.Recipe.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
+import sejong.capston.yechef.domain.Recipe.service.RecipeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/{memberId}/recipes")
+public class RecipeController {
+
+  private final RecipeService recipeService;
+
+  @PostMapping
+  public ResponseEntity<RecipeDto> createRecipe(
+      @PathVariable Long memberId,
+      @RequestBody RecipeCreateDto dto
+  ) {
+    return ResponseEntity.ok(recipeService.create(memberId, dto));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<RecipeDto>> getMyRecipes(@PathVariable Long memberId) {
+    return ResponseEntity.ok(recipeService.getMyRecipes(memberId));
+  }
+
+  @GetMapping("/{recipeId}")
+  public ResponseEntity<RecipeDto> getRecipe(@PathVariable Long recipeId) {
+    return ResponseEntity.ok(recipeService.getRecipe(recipeId));
+  }
+
+  @DeleteMapping("/{recipeId}")
+  public ResponseEntity<Void> deleteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
+    recipeService.delete(memberId, recipeId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping("/{recipeId}/like")
+  public ResponseEntity<Void> toggleLike(@PathVariable Long memberId, @PathVariable Long recipeId) {
+    recipeService.toggleLike(memberId, recipeId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeCreateDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeCreateDto.java
@@ -1,0 +1,11 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+@Getter
+public class RecipeCreateDto {
+  private String title;
+  private Recipe.RecipeType recipeType;
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
@@ -1,0 +1,28 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecipeDto {
+  private Long id;
+  private String title;
+  private String author;
+  private Recipe.RecipeType recipeType;
+  private int likeCount;
+
+  public static RecipeDto from(Recipe recipe) {
+    return RecipeDto.builder()
+        .id(recipe.getId())
+        .title(recipe.getTitle())
+        .author(recipe.getAuthor())
+        .recipeType(recipe.getRecipeType())
+        .likeCount(recipe.getLikeCount())
+        .build();
+  }
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeResponseDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeResponseDto.java
@@ -1,0 +1,26 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeResponseDto {
+  private Long id;
+  private String title;
+  private String author;
+  private Recipe.RecipeType recipeType;
+
+  public static RecipeResponseDto from(Recipe recipe) {
+    return new RecipeResponseDto(
+        recipe.getId(),
+        recipe.getTitle(),
+        recipe.getAuthor(),
+        recipe.getRecipeType()
+    );
+  }
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeStepResponseDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeStepResponseDto.java
@@ -1,0 +1,15 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeStepResponseDto {
+  private String gptResult;
+  private int stepNumber;
+  private String currentStepDescription;
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/IngredientRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/IngredientRepository.java
@@ -1,0 +1,10 @@
+package sejong.capston.yechef.domain.Recipe.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import sejong.capston.yechef.domain.Ingredients.Ingredient;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+  List<Ingredient> findByRecipe(Recipe recipe);
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeRepository.java
@@ -1,0 +1,14 @@
+package sejong.capston.yechef.domain.Recipe.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+  @Query("SELECT r FROM Recipe r JOIN r.memberRecipes mr WHERE mr.member.id = :memberId")
+  List<Recipe> findByMemberId(@Param("memberId") Long memberId);
+
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeStepRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeStepRepository.java
@@ -1,0 +1,10 @@
+package sejong.capston.yechef.domain.Recipe.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
+
+public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
+  Optional<RecipeStep> findByRecipeAndStepNumber(Recipe recipe, int stepNumber);
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
@@ -1,0 +1,67 @@
+package sejong.capston.yechef.domain.Recipe.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sejong.capston.yechef.domain.Gpt.service.GptService;
+import sejong.capston.yechef.domain.Ingredients.Ingredient;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeStepResponseDto;
+import sejong.capston.yechef.domain.Recipe.repository.IngredientRepository;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeStepRepository;
+import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeProgressService {
+
+  private final RecipeRepository recipeRepository;
+  private final RecipeStepRepository recipeStepRepository;
+  private final IngredientRepository ingredientRepository;
+  private final GptService gptService;
+
+  public RecipeStepResponseDto processStep(Long recipeId, int stepNumber, String userInput) {
+    // 레시피 & 단계 조회
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("Recipe not found"));
+
+    RecipeStep currentStep = recipeStepRepository.findByRecipeAndStepNumber(recipe, stepNumber)
+        .orElseThrow(() -> new IllegalArgumentException("해당 단계 없음"));
+
+    // 재료 조회
+    List<Ingredient> ingredients = ingredientRepository.findByRecipe(recipe);
+
+    // GPT 프롬프트 구성 및 호출
+    String gptPrompt = buildPrompt(currentStep.getDescription(), userInput, ingredients);
+    String gptResult = gptService.simplePrompt(gptPrompt);
+
+    return RecipeStepResponseDto.builder()
+        .gptResult(gptResult)
+        .stepNumber(stepNumber)
+        .currentStepDescription(currentStep.getDescription())
+        .build();
+  }
+
+  private String buildPrompt(String stepDescription, String userInput, List<Ingredient> ingredients) {
+    String formattedIngredients = ingredients.stream()
+        .map(i -> "- %s (%s)".formatted(i.getOriginalName(), i.getOriginalAmount()))
+        .collect(Collectors.joining("\n"));
+
+    return """
+      현재 요리 단계: "%s"
+      사용자의 음성 입력: "%s"
+
+      레시피 재료 목록:
+      %s
+
+      아래 중 하나만 출력하세요:
+      - "NEXT": 다음 단계로 넘어갈 수 있음
+      - "REPEAT": 다시 설명 필요
+      - "EXPLAIN: <설명>": 보조 설명 필요
+      """.formatted(stepDescription, userInput, formattedIngredients);
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -1,0 +1,73 @@
+package sejong.capston.yechef.domain.Recipe.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sejong.capston.yechef.domain.Member.Member;
+import sejong.capston.yechef.domain.Member.repository.MemberRepository;
+import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
+import sejong.capston.yechef.domain.MemberRecipe.MemberRecipeRepository;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+
+  private final RecipeRepository recipeRepository;
+  private final MemberRepository memberRepository;
+  private final MemberRecipeRepository memberRecipeRepository;
+
+  @Transactional
+  public RecipeDto create(Long memberId, RecipeCreateDto dto) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+
+    Recipe recipe = Recipe.builder()
+        .title(dto.getTitle())
+        .author(member.getNickname())
+        .likeCount(0)
+        .ranking(0.0)
+        .recipeType(dto.getRecipeType())
+        .isUpdated(false)
+        .build();
+    recipeRepository.save(recipe);
+
+    MemberRecipe memberRecipe = new MemberRecipe(member, recipe);
+    memberRecipeRepository.save(memberRecipe);
+
+    return RecipeDto.from(recipe);
+  }
+
+  @Transactional(readOnly = true)
+  public List<RecipeDto> getMyRecipes(Long memberId) {
+    List<Recipe> recipes = recipeRepository.findByMemberId(memberId);
+    return recipes.stream().map(RecipeDto::from).collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public RecipeDto getRecipe(Long recipeId) {
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("레시피가 존재하지 않습니다."));
+    return RecipeDto.from(recipe);
+  }
+
+  @Transactional
+  public void delete(Long memberId, Long recipeId) {
+    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 레시피가 아닙니다."));
+    recipeRepository.delete(memberRecipe.getRecipe());
+  }
+
+  @Transactional
+  public void toggleLike(Long memberId, Long recipeId) {
+    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("레시피 좋아요 정보가 없습니다."));
+    memberRecipe.toggleLike();
+  }
+}


### PR DESCRIPTION
## 🧩 이슈
- 레시피 기능 구현 및 GPT 연동 처리

## ✅ 구현 기능
- 레시피 요청/응답용 DTO 클래스 정의 (`RecipeDto`, `RecipeCreateDto` 등)
- 레시피 관련 JPA Repository 구현 (`RecipeRepository`, `RecipeStepRepository`, `IngredientRepository`)
- `RecipeController` 생성 및 CRUD API 구현
- `RecipeService`, `RecipeProgressService` 생성 및 GPT 진행 흐름 처리
- 회원 정보 수정 시 `showExamplePhoto` 설정 필드 추가
- 단순 텍스트 요청 처리를 위한 GPT `simplePrompt()` 메서드 추가

