### PR TITLE
Feat member

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -41,6 +42,13 @@ public class MemberRecipe extends BaseEntity {
 
   public void toggleLike() {
     this.isLiked = !this.isLiked;
+  }
+
+  @Builder
+  public MemberRecipe(Member member, Recipe recipe) {
+    this.member = member;
+    this.recipe = recipe;
+    this.isLiked = false;
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipeRepository.java
@@ -1,0 +1,11 @@
+package sejong.capston.yechef.domain.MemberRecipe;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long> {
+
+  Optional<MemberRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
+
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
@@ -1,0 +1,67 @@
+package sejong.capston.yechef.domain.Recipe.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sejong.capston.yechef.domain.Gpt.service.GptService;
+import sejong.capston.yechef.domain.Ingredients.Ingredient;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeStepResponseDto;
+import sejong.capston.yechef.domain.Recipe.repository.IngredientRepository;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeStepRepository;
+import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeProgressService {
+
+  private final RecipeRepository recipeRepository;
+  private final RecipeStepRepository recipeStepRepository;
+  private final IngredientRepository ingredientRepository;
+  private final GptService gptService;
+
+  public RecipeStepResponseDto processStep(Long recipeId, int stepNumber, String userInput) {
+    // 레시피 & 단계 조회
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("Recipe not found"));
+
+    RecipeStep currentStep = recipeStepRepository.findByRecipeAndStepNumber(recipe, stepNumber)
+        .orElseThrow(() -> new IllegalArgumentException("해당 단계 없음"));
+
+    // 재료 조회
+    List<Ingredient> ingredients = ingredientRepository.findByRecipe(recipe);
+
+    // GPT 프롬프트 구성 및 호출
+    String gptPrompt = buildPrompt(currentStep.getDescription(), userInput, ingredients);
+    String gptResult = gptService.simplePrompt(gptPrompt);
+
+    return RecipeStepResponseDto.builder()
+        .gptResult(gptResult)
+        .stepNumber(stepNumber)
+        .currentStepDescription(currentStep.getDescription())
+        .build();
+  }
+
+  private String buildPrompt(String stepDescription, String userInput, List<Ingredient> ingredients) {
+    String formattedIngredients = ingredients.stream()
+        .map(i -> "- %s (%s)".formatted(i.getOriginalName(), i.getOriginalAmount()))
+        .collect(Collectors.joining("\n"));
+
+    return """
+      현재 요리 단계: "%s"
+      사용자의 음성 입력: "%s"
+
+      레시피 재료 목록:
+      %s
+
+      아래 중 하나만 출력하세요:
+      - "NEXT": 다음 단계로 넘어갈 수 있음
+      - "REPEAT": 다시 설명 필요
+      - "EXPLAIN: <설명>": 보조 설명 필요
+      """.formatted(stepDescription, userInput, formattedIngredients);
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -1,0 +1,73 @@
+package sejong.capston.yechef.domain.Recipe.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sejong.capston.yechef.domain.Member.Member;
+import sejong.capston.yechef.domain.Member.repository.MemberRepository;
+import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
+import sejong.capston.yechef.domain.MemberRecipe.MemberRecipeRepository;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+
+  private final RecipeRepository recipeRepository;
+  private final MemberRepository memberRepository;
+  private final MemberRecipeRepository memberRecipeRepository;
+
+  @Transactional
+  public RecipeDto create(Long memberId, RecipeCreateDto dto) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+
+    Recipe recipe = Recipe.builder()
+        .title(dto.getTitle())
+        .author(member.getNickname())
+        .likeCount(0)
+        .ranking(0.0)
+        .recipeType(dto.getRecipeType())
+        .isUpdated(false)
+        .build();
+    recipeRepository.save(recipe);
+
+    MemberRecipe memberRecipe = new MemberRecipe(member, recipe);
+    memberRecipeRepository.save(memberRecipe);
+
+    return RecipeDto.from(recipe);
+  }
+
+  @Transactional(readOnly = true)
+  public List<RecipeDto> getMyRecipes(Long memberId) {
+    List<Recipe> recipes = recipeRepository.findByMemberId(memberId);
+    return recipes.stream().map(RecipeDto::from).collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public RecipeDto getRecipe(Long recipeId) {
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("레시피가 존재하지 않습니다."));
+    return RecipeDto.from(recipe);
+  }
+
+  @Transactional
+  public void delete(Long memberId, Long recipeId) {
+    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 레시피가 아닙니다."));
+    recipeRepository.delete(memberRecipe.getRecipe());
+  }
+
+  @Transactional
+  public void toggleLike(Long memberId, Long recipeId) {
+    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
+        .orElseThrow(() -> new EntityNotFoundException("레시피 좋아요 정보가 없습니다."));
+    memberRecipe.toggleLike();
+  }
+}


### PR DESCRIPTION
## ✅ 이슈
- 회원별 레시피 진행 및 기록 관리를 위한 기능 구현

## ✅ 구현 기능
- `MemberRecipe` 엔티티에 생성자 추가 및 `Member`-`Recipe` 연관 매핑을 위한 Repository 정의
- 조리 단계별 진행 처리를 위한 서비스(`RecipeProgressService`, `RecipeService`) 구현

