### PR TITLE
feat: 이미지 저장용 엔티티 및 레시피 진행 API 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Image.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Image.java
@@ -1,0 +1,20 @@
+package sejong.capston.yechef.domain.Recipe;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Image {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String s3Url;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Recipe recipe;
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeProgressController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeProgressController.java
@@ -1,0 +1,33 @@
+package sejong.capston.yechef.domain.Recipe.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeStepResponseDto;
+import sejong.capston.yechef.domain.Recipe.dto.VoiceInputDto;
+import sejong.capston.yechef.domain.Recipe.service.RecipeProgressService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/{memberId}/recipes")
+public class RecipeProgressController {
+
+  private final RecipeProgressService progressService;
+
+  @PostMapping("/{recipeId}/step/{stepNumber}/progress")
+  public ResponseEntity<RecipeStepResponseDto> progressStep(
+      @PathVariable Long memberId,
+      @PathVariable Long recipeId,
+      @PathVariable int stepNumber,
+      @RequestBody VoiceInputDto input
+  ) {
+    return ResponseEntity.ok(
+        progressService.processStep(recipeId, stepNumber, input.getText())
+    );
+  }
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/VoiceInputDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/VoiceInputDto.java
@@ -1,0 +1,11 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VoiceInputDto {
+  private String text;
+}
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/ImageRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package sejong.capston.yechef.domain.Recipe.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sejong.capston.yechef.domain.Recipe.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}


### PR DESCRIPTION
# 이슈
- [레시피 음성 진행 및 이미지 업로드 DB 연동]

# 구현 기능
- 이미지 정보를 DB에 저장하기 위한 `Image` 엔티티 및 `ImageRepository` 추가
- 음성 입력 텍스트를 처리하기 위한 `VoiceInputDto` 생성
- 레시피 진행 단계별 입력 텍스트를 기반으로 처리하는 컨트롤러 API 추가
  - `/api/members/{memberId}/recipes/{recipeId}/step/{stepNumber}/progress`

# 기타
- 레시피 진행 판단은 GPT 연동 전제
- Image 엔티티는 S3 업로드 기능과 연결되어 확장
