### PR TITLE
chore: S3 의존성 및 MySQL 외부 접속 설정 추가

### DIFF
--- a/yechef/build.gradle
+++ b/yechef/build.gradle
@@ -53,6 +53,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// S3
+	implementation platform("software.amazon.awssdk:bom:2.25.2") // 버전 BOM
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:auth'
+	implementation 'software.amazon.awssdk:regions'
 }
 
 tasks.named('test') {

--- a/yechef/docker-compose.yml
+++ b/yechef/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   mysql:
     image: mysql:8.0
+    ports:
+      - "3306:3306"
     env_file:
       - .env
     environment:

--- a/yechef/src/main/resources/application.yml
+++ b/yechef/src/main/resources/application.yml
@@ -52,3 +52,7 @@ logging:
     root: ${LOG_LEVEL:INFO}
     com.example: ${LOG_LEVEL_COM_EXAMPLE:DEBUG}
 
+cloud:
+  aws:
+    s3:
+      bucket: yeojung-bucket


### PR DESCRIPTION
# 이슈
- [환경 설정 개선: S3 및 DB 연동을 위한 설정 추가]

# 구현 기능
- AWS SDK for Java 의존성 추가 (S3 연동용)
- MySQL Docker 컨테이너의 3306 포트를 외부로 노출하여 Workbench 등 외부에서 연결 가능하도록 설정

# 기타
- AWS S3 업로드 기능 구현을 위한 기반 작업
- DB 접근 허용은 보안 그룹 설정과 함께 테스트 필요
