### PR TITLE
[fix] S3 업로드 시 버킷 및 region 하드코딩 제거 및 필드 기반으로 수정

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/s3/service/S3UploadService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/s3/service/S3UploadService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import sejong.capston.yechef.domain.Recipe.Image;
@@ -23,19 +24,22 @@ public class S3UploadService {
   private final S3Client s3Client;
   private final ImageRepository imageRepository;
 
-  private final String bucketName;
-  private final String bucketName;
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucketName;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
 
   /**
    * S3에 파일 업로드 후 URL 반환
    */
   public String uploadFile(MultipartFile file) {
     String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
-    String fileUrl = "https://" + BUCKET_NAME + ".s3." + s3Client.region().id() + ".amazonaws.com/" + fileName;
+    String fileUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + fileName;
 
     try (InputStream inputStream = file.getInputStream()) {
       PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-          .bucket(BUCKET_NAME)
+          .bucket(bucketName)
           .key(fileName)
           .contentType(file.getContentType())
           .acl(ObjectCannedACL.PUBLIC_READ)


### PR DESCRIPTION
# 이슈
- [S3 이미지 업로드 region 참조 오류 수정]

# 구현 기능
- S3 업로드 URL 생성 시 `s3Client.region()` 사용 → `@Value`로 주입받은 `region` 필드로 수정
- 하드코딩된 `BUCKET_NAME` 상수 제거, `@Value`로 주입된 `bucketName` 필드로 대체
- 업로드 URL 포맷 문자열 정리

# 비고
- 해당 수정으로 컴파일 에러 해결
- `application.yml` 설정 정상 주입 확인
