### PR TITLE
[feat] 카카오 이미지 검색용 WebClient 설정 및 에러 코드 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/controller/KakaoImageController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/controller/KakaoImageController.java
@@ -1,0 +1,24 @@
+package sejong.capston.yechef.domain.KakaoImage.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.KakaoImage.dto.KakaoImageResponseDto;
+import sejong.capston.yechef.domain.KakaoImage.service.KakaoImageService;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class KakaoImageController {
+
+  private final KakaoImageService kakaoImageService;
+
+  @GetMapping
+  public ResponseEntity<KakaoImageResponseDto> search(@RequestParam String query) {
+    KakaoImageResponseDto result = kakaoImageService.searchImage(query);
+    return ResponseEntity.ok(result);
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/dto/KakaoImageResponseDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/dto/KakaoImageResponseDto.java
@@ -1,0 +1,29 @@
+package sejong.capston.yechef.domain.KakaoImage.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class KakaoImageResponseDto {
+
+  private List<Document> documents;
+
+  @Getter
+  public static class Document {
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @JsonProperty("thumbnail_url")
+    private String thumbnailUrl;
+
+    @JsonProperty("display_sitename")
+    private String siteName;
+
+    @JsonProperty("doc_url")
+    private String docUrl;
+
+    private int width;
+    private int height;
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
@@ -1,0 +1,36 @@
+package sejong.capston.yechef.domain.KakaoImage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import sejong.capston.yechef.domain.KakaoImage.dto.KakaoImageResponseDto;
+import sejong.capston.yechef.global.exception.BaseException;
+import sejong.capston.yechef.global.exception.error.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoImageService {
+
+  private final WebClient kakaoImageWebClient;
+
+  public KakaoImageResponseDto searchImage(String query) {
+    try {
+      return kakaoImageWebClient.get()
+          .uri(uriBuilder -> uriBuilder
+              .path("/v2/search/image")
+              .queryParam("query", query)
+              .queryParam("sort", "accuracy")
+              .queryParam("page", 1)
+              .queryParam("size", 3) // 여러 개 받고 싶으면 size 늘리기
+              .build())
+          .retrieve()
+          .bodyToMono(KakaoImageResponseDto.class)
+          .block();
+    }catch (WebClientResponseException e) {
+      throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "카카오 이미지 API 응답 오류: " + e.getStatusCode());
+    } catch (Exception e) {
+      throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "카카오 이미지 API 호출 실패: " + e.getMessage());
+    }
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/global/config/KakaoImageConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/KakaoImageConfig.java
@@ -1,0 +1,23 @@
+package sejong.capston.yechef.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@Getter
+public class KakaoImageConfig {
+
+  @Value("${KAKAO_REST_API_KEY}")
+  private String apiKey;
+
+  @Bean
+  public WebClient kakaoImageWebClient() {
+    return WebClient.builder()
+        .baseUrl("https://dapi.kakao.com")
+        .defaultHeader("Authorization", "KakaoAK " + apiKey)
+        .build();
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -35,8 +35,10 @@ public enum ErrorCode {
     GPT_RESPONSE_PARSING_FAILED("GPT-0000", "GPT 응답 파싱에 실패했습니다.", ErrorDisplayType.POPUP),
 
     //s3
-    FILE_UPLOAD_FAIL("S3_001", "파일 업로드에 실패했습니다.", ErrorDisplayType.TOAST)
+    FILE_UPLOAD_FAIL("S3_001", "파일 업로드에 실패했습니다.", ErrorDisplayType.TOAST),
 
+    // kakao img api
+    KAKAO_API_ERROR("K001", "카카오 이미지 검색 중 오류 발생", ErrorDisplayType.TOAST)
     ;
 
     private final String code;


### PR DESCRIPTION
# 이슈
[카카오 이미지 검색 기능 구현]

# 구현 기능
- `KakaoImageConfig.java` 추가  
  - 카카오 이미지 검색 API 호출용 WebClient Bean 등록  
  - Authorization 헤더 자동 설정 (`KakaoAK {apiKey}`)
- `ErrorCode.java`에 `KAKAO_API_ERROR` 추가  
  - 이미지 검색 실패 시 예외 응답 처리를 위한 코드 정의