### PR TITLE
[feat] Swagger에 JWT Bearer 인증 설정 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SwaggerConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SwaggerConfig.java
@@ -2,30 +2,40 @@ package sejong.capston.yechef.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import java.util.List;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import io.swagger.v3.oas.models.servers.Server;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
 
   @Bean
   public OpenAPI customOpenAPI() {
+    final String securitySchemeName = "BearerAuth";
+
     return new OpenAPI()
         .info(new Info()
             .title("My API Docs")
             .version("1.0")
             .description("API 문서 설명"))
+        .addSecurityItem(new SecurityRequirement().addList(securitySchemeName)) // 🔐 보안 적용
+        .components(new Components()
+            .addSecuritySchemes(securitySchemeName,
+                new SecurityScheme()
+                    .name(securitySchemeName)
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")  // JWT 형식 명시
+            )
+        )
         .servers(List.of(
             new Server().url("http://localhost:8080").description("Local 개발 서버"),
             new Server().url("http://43.203.72.240:8080").description("운영 서버")
         ));
-
   }
 }
-
-
-
-
-


### PR DESCRIPTION
# 이슈
[Swagger에 인증 설정 추가]

# 구현 기능
- Swagger 설정 클래스(SwaggerConfig)에 Bearer 인증 스키마 적용
- securitySchemeName 상수로 관리
- JWT 인증 헤더(Authorization: Bearer <token>)를 Swagger UI에서 테스트 가능하게 구성