### PR TITLE
[feat] 레시피 이미지 자동 저장 기능

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
@@ -16,6 +16,6 @@ public class Image {
 
   private String s3Url;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @OneToOne(fetch = FetchType.LAZY)
   private Recipe recipe;
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/controller/ImageController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/controller/ImageController.java
@@ -1,0 +1,24 @@
+package sejong.capston.yechef.domain.Image.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.Image.service.ImageService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image")
+public class ImageController {
+
+  // test용
+  private final ImageService imageService;
+
+  @PostMapping("/generate")
+  public ResponseEntity<Void> generate(@RequestParam Long recipeId) {
+    imageService.generateAndSaveImageForRecipe(recipeId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
@@ -1,0 +1,38 @@
+package sejong.capston.yechef.domain.Image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sejong.capston.yechef.domain.Image.Image;
+import sejong.capston.yechef.domain.Image.repository.ImageRepository;
+import sejong.capston.yechef.domain.KakaoImage.service.KakaoImageService;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+import sejong.capston.yechef.global.exception.BaseException;
+import sejong.capston.yechef.global.exception.error.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private final ImageRepository imageRepository;
+  private final RecipeRepository recipeRepository;
+  private final KakaoImageService kakaoImageService;
+
+  @Transactional
+  public void generateAndSaveImageForRecipe(Long recipeId) {
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST, "해당 레시피가 존재하지 않습니다."));
+
+    String imageUrl = kakaoImageService.getTopImageUrl(recipe.getTitle());
+
+    Image image = Image.builder()
+        .s3Url(imageUrl)
+        .recipe(recipe)
+        .build();
+
+    imageRepository.save(image);
+
+    recipe.setImage(image);
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
@@ -33,4 +33,12 @@ public class KakaoImageService {
       throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "카카오 이미지 API 호출 실패: " + e.getMessage());
     }
   }
+
+  public String getTopImageUrl(String keyword) {
+    KakaoImageResponseDto response = searchImage(keyword);
+    if (response.getDocuments().isEmpty()) {
+      throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "이미지 검색 결과가 없습니다.");
+    }
+    return response.getDocuments().get(0).getImageUrl();
+  }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import sejong.capston.yechef.domain.Image.Image;
 import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
 import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
 import sejong.capston.yechef.global.entity.BaseEntity;
@@ -51,6 +52,9 @@ public class Recipe extends BaseEntity {
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<MemberRecipe> memberRecipes = new ArrayList<>();
+
+    @OneToOne(mappedBy = "recipe", fetch = FetchType.LAZY)
+    private Image image;
 
     @Builder
     public Recipe(

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
@@ -53,7 +53,7 @@ public class Recipe extends BaseEntity {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<MemberRecipe> memberRecipes = new ArrayList<>();
 
-    @OneToOne(mappedBy = "recipe", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Image image;
 
     @Builder


### PR DESCRIPTION
# 이슈
[레시피 생성 시 대표 이미지 자동 지정 기능]

# 구현 기능
- 기존 Image ↔ Recipe 관계를 OneToOne 양방향으로 수정
- Kakao 이미지 검색 API 결과에서 대표 이미지 URL 추출 메서드 추가
- 레시피 제목 기반으로 Kakao 이미지 검색 후 대표 이미지 저장
- /api/image/generate?recipeId=... API 구현