### PR TITLE
[refactor] 에러 코드 형식 통일

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -35,10 +35,10 @@ public enum ErrorCode {
     GPT_RESPONSE_PARSING_FAILED("GPT-0000", "GPT 응답 파싱에 실패했습니다.", ErrorDisplayType.POPUP),
 
     //s3
-    FILE_UPLOAD_FAIL("S3_001", "파일 업로드에 실패했습니다.", ErrorDisplayType.TOAST),
+    FILE_UPLOAD_FAIL("S3-001", "파일 업로드에 실패했습니다.", ErrorDisplayType.TOAST),
 
     // kakao img api
-    KAKAO_API_ERROR("K001", "카카오 이미지 검색 중 오류 발생", ErrorDisplayType.TOAST)
+    KAKAO_API_ERROR("K-001", "카카오 이미지 검색 중 오류 발생", ErrorDisplayType.TOAST)
     ;
 
     private final String code;


### PR DESCRIPTION
#이슈
- [에러코드 규칙 일관성 통일]

# 구현 기능
- 기존 에러 코드 중 일부 항목의 코드 문자열에 하이픈(`-`) 추가
  - `"K001"` → `"K-001"`
  - `"S3_001"` → `"S3-001"`
- 코드 포맷을 `영문 prefix + 하이픈 + 3자리 숫자` 형식으로 통일