### PR TITLE
[feat] 이미지 검색 API에 대해 permitAll 설정 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                         "/favicon.ico", "/static/**", "/css/**", "/js/**", "/images/**",
                         "/bot", "/bot/**",  // gpt api
                         "/swagger-ui/**",
-                        "/v3/api-docs/**"
+                        "/v3/api-docs/**",
+                        "/api/images"
                 ).permitAll()
 
 


### PR DESCRIPTION
# 이슈
- [카카오 이미지 검색 API를 인증 없이 사용할 수 있도록 허용]

# 구현 기능
- SecurityConfig에 `/api/images` 경로를 `permitAll()`로 추가
- Swagger에서 인증 없이 이미지 검색 API 호출 가능하도록 허용