### PR TITLE
[feat] 레시피 좋아요 기능 및 컨트롤러 리팩터링

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/MemberRecipe.java
@@ -44,11 +44,16 @@ public class MemberRecipe extends BaseEntity {
     this.isLiked = !this.isLiked;
   }
 
+  @NonNull
+  private Boolean isOwner = false;
+
+
   @Builder
-  public MemberRecipe(Member member, Recipe recipe) {
+  public MemberRecipe(Member member, Recipe recipe, Boolean isLiked, Boolean isOwner) {
     this.member = member;
     this.recipe = recipe;
-    this.isLiked = false;
+    this.isLiked = isLiked != null ? isLiked : false;
+    this.isOwner = isOwner != null ? isOwner : false;
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/controller/MemberRecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/controller/MemberRecipeController.java
@@ -1,0 +1,42 @@
+package sejong.capston.yechef.domain.MemberRecipe.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
+import sejong.capston.yechef.domain.Recipe.service.RecipeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member-recipes")
+public class MemberRecipeController {
+
+  private final RecipeService recipeService;
+
+  @PatchMapping("/{memberId}/recipes/{recipeId}/like")
+  public ResponseEntity<Void> toggleLike(
+      @PathVariable Long memberId,
+      @PathVariable Long recipeId
+  ) {
+    recipeService.toggleLike(memberId, recipeId);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{memberId}/my-recipes")
+  public List<RecipeDto> getMyRecipes(@PathVariable Long memberId) {
+    return recipeService.getMyRecipes(memberId);
+  }
+
+  // 향후 확장을 위한 좋아요 목록 예시
+  @GetMapping("/{memberId}/likes")
+  public List<RecipeDto> getLikedRecipes(@PathVariable Long memberId) {
+    return recipeService.getLikedRecipes(memberId); // 메서드 직접 구현 필요
+  }
+}
+
+

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/repository/MemberRecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/repository/MemberRecipeRepository.java
@@ -1,12 +1,15 @@
 package sejong.capston.yechef.domain.MemberRecipe.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
+import sejong.capston.yechef.domain.Recipe.Recipe;
 
 public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long> {
 
   Optional<MemberRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
 
+  List<Recipe> findLikedRecipesByMemberId(Long memberId);
 }
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -1,54 +1,42 @@
 package sejong.capston.yechef.domain.Recipe.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.service.RecipeService;
+import sejong.capston.yechef.domain.Member.dto.LoginMemberDto;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/members/{memberId}/recipes")
+@RequestMapping("/api/recipes")
 public class RecipeController {
 
   private final RecipeService recipeService;
 
   @PostMapping
   public RecipeDto createRecipe(
-      @PathVariable Long memberId,
+      @AuthenticationPrincipal LoginMemberDto user,
       @RequestBody RecipeCreateDto dto
   ) {
-    return recipeService.create(memberId, dto);
-  }
-
-  @GetMapping
-  public List<RecipeDto> getMyRecipes(@PathVariable Long memberId) {
-    return recipeService.getMyRecipes(memberId);
+    return recipeService.create(user.getId(), dto);
   }
 
   @GetMapping("/{recipeId}")
-  public RecipeDto getRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
+  public RecipeDto getRecipe(@PathVariable Long recipeId) {
     return recipeService.getRecipe(recipeId);
   }
 
   @DeleteMapping("/{recipeId}")
-  public ResponseEntity<Void> deleteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
-    recipeService.delete(memberId, recipeId);
+  public ResponseEntity<Void> deleteRecipe(
+      @AuthenticationPrincipal LoginMemberDto user,
+      @PathVariable Long recipeId
+  ) {
+    recipeService.delete(user.getId(), recipeId);
     return ResponseEntity.noContent().build();
   }
 
-  @PatchMapping("/{recipeId}/like")
-  public ResponseEntity<Void> toggleLike(@PathVariable Long memberId, @PathVariable Long recipeId) {
-    recipeService.toggleLike(memberId, recipeId);
-    return ResponseEntity.ok().build();
-  }
+
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -32,7 +32,7 @@ public class RecipeService {
 
     Recipe recipe = Recipe.builder()
         .title(dto.getTitle())
-        .author(member.getNickname())
+        .author(member.getNickname()) // 추후 Member 참조로 바꾸는 것도 추천
         .likeCount(0)
         .ranking(0.0)
         .recipeType(dto.getRecipeType())
@@ -40,7 +40,12 @@ public class RecipeService {
         .build();
     recipeRepository.save(recipe);
 
-    MemberRecipe memberRecipe = new MemberRecipe(member, recipe);
+    MemberRecipe memberRecipe = MemberRecipe.builder()
+        .member(member)
+        .recipe(recipe)
+        .isOwner(true)
+        .isLiked(false)
+        .build();
     memberRecipeRepository.save(memberRecipe);
 
     return RecipeDto.from(recipe);
@@ -68,8 +73,38 @@ public class RecipeService {
 
   @Transactional
   public void toggleLike(Long memberId, Long recipeId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
+
     MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
-        .orElseThrow(() -> BaseException.from(ErrorCode.NO_RECIPE_INFO_OF_LIKE));
-    memberRecipe.toggleLike();
+        .orElse(null);
+
+    if (memberRecipe == null) {
+      // 처음 좋아요 누름 → 새로 생성
+      memberRecipe = MemberRecipe.builder()
+          .member(member)
+          .recipe(recipe)
+          .isOwner(false)
+          .isLiked(true)
+          .build();
+      memberRecipeRepository.save(memberRecipe);
+      recipe.setLikeCount(recipe.getLikeCount() + 1);
+    } else {
+      // 기존 존재 → 좋아요 토글
+      boolean wasLiked = memberRecipe.getIsLiked();
+      memberRecipe.toggleLike();
+      recipe.setLikeCount(recipe.getLikeCount() + (memberRecipe.getIsLiked() ? 1 : -1));
+    }
   }
+  @Transactional(readOnly = true)
+  public List<RecipeDto> getLikedRecipes(Long memberId) {
+    List<Recipe> likedRecipes = memberRecipeRepository.findLikedRecipesByMemberId(memberId);
+    return likedRecipes.stream()
+        .map(RecipeDto::from)
+        .collect(Collectors.toList());
+  }
+
+
 }


### PR DESCRIPTION
# 이슈
- [레시피 좋아요 기능 구현]
- [레시피 컨트롤러 리팩터링]

# 구현 기능

## [feat] 레시피 좋아요 토글 및 좋아요한 레시피 조회 기능 추가
- `MemberRecipe`를 통해 사용자-레시피 간 좋아요 상태 저장
- 처음 좋아요 시 `isLiked = true`로 새 레코드 생성
- 기존 좋아요 존재 시 상태 토글 및 `likeCount` 증감 반영
- 좋아요한 레시피 목록 조회 기능 추가
- `/api/member-recipes/{memberId}/likes` 경로로 조회 가능
- 관련 기능은 `MemberRecipeController`, `RecipeService`에 위치

## [refactor] 레시피 생성 및 삭제 컨트롤러 구조 개선
- PathVariable 기반 `memberId` 전달 제거
- `@AuthenticationPrincipal` 기반 사용자 인증 정보 활용
- `RecipeController`, `RecipeService` 내부 구조 간소화 및 정리
