### PR TITLE
[chore] 중복된 Cors설정 제거

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
@@ -23,7 +23,6 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.cors(withDefaults())
             .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (쿠키 기반 인증에서는 CSRF 보호 필요할 수도 있음)
-            .cors(withDefaults())
             .formLogin((auth) -> auth.disable())
             .httpBasic((auth) -> auth.disable())
             .exceptionHandling(e ->


### PR DESCRIPTION
# 이슈
- [Spring Security 설정 정리 및 중복 제거]

# 구현 기능
- `SecurityConfig.java` 내 중복된 `.cors(withDefaults())` 설정 제거
- `http.cors(...)`가 이미 선언되어 있어 아래 중복 설정 제거
- `SecurityFilterChain` 내 설정 순서를 정리하여 가독성 개선
- 전반적인 Spring Security 필터 구성 명확화