### PR TITLE
[refactor] MemberRecipe 생성 방식 Builder 패턴으로 수정

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
@@ -34,12 +34,11 @@ public class GptRecipeService {
     private final RecipeRepository recipeRepository;
     private final MemberRepository memberRepository;
     private final MemberRecipeRepository memberRecipeRepository;
-
     @Transactional
     public RecipeResponseDto createFromRaw(Long memberId, String rawRecipe, SaveRecipeRequest request) {
         // 회원 조회
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
 
         // GPT로 파싱
         IngredientAndRecipeDto recipeDtoToSave = gptService.parseRecipe(rawRecipe);
@@ -48,8 +47,13 @@ public class GptRecipeService {
         Recipe recipe = Recipe.of(request.getTitle(), member.getNickname(), request.getRecipeType());
         recipeRepository.save(recipe);
 
-        // MemberRecipe 연결 저장
-        MemberRecipe memberRecipe = new MemberRecipe(member, recipe);
+        // MemberRecipe 연결 저장 (수정된 부분)
+        MemberRecipe memberRecipe = MemberRecipe.builder()
+            .member(member)
+            .recipe(recipe)
+            .isOwner(true)   // GPT로 생성된 레시피는 사용자 본인이 만든 것이므로 true
+            .isLiked(false)  // 초기 상태는 좋아요 X
+            .build();
         memberRecipeRepository.save(memberRecipe);
 
         // Ingredient 저장
@@ -60,4 +64,5 @@ public class GptRecipeService {
 
         return RecipeResponseDto.from(recipe);
     }
+
 }


### PR DESCRIPTION
# 이슈
- [GPT 레시피 생성 시 MemberRecipe 연결 오류 수정]

# 구현 기능
- `GptRecipeService`에서 `new MemberRecipe(member, recipe)` 사용 시 컴파일 오류 발생
- 현재 `MemberRecipe`는 `@Builder` 기반의 4개 인자 생성자를 사용하므로, 빌더 패턴으로 생성 방식 수정
