### PR TITLE
[feat] GPT 파싱 응답에 title 필드 추가 및 레시피 제목 저장 기능 구현

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/controller/GptApiController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/controller/GptApiController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
-import sejong.capston.yechef.domain.Gpt.dto.IngredientAndRecipeDto;
+import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Gpt.service.GptService;
 
 @RestController
@@ -28,7 +28,7 @@ public class GptApiController {
     private RestTemplate template;
 
     @GetMapping("/parseRecipe")
-    public IngredientAndRecipeDto parseRecipe(@RequestParam("recipe") String rawRecipe) {
+    public RecipeParseResultDto parseRecipe(@RequestParam("recipe") String rawRecipe) {
         return gptService.parseRecipe(rawRecipe);
     }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/controller/GptRecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/controller/GptRecipeController.java
@@ -4,24 +4,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sejong.capston.yechef.domain.Gpt.dto.ChatGPTResponse;
-import sejong.capston.yechef.domain.Recipe.dto.RecipeResponseDto;
 import sejong.capston.yechef.domain.Gpt.service.GptRecipeService;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeResponseDto;
 import sejong.capston.yechef.domain.Recipe.dto.SaveRecipeRequest;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/gpt/recipes")
-@Tag(name = "GPT 레시피 생성", description = "GPT를 이용해 레시피 텍스트를 파싱하고 저장하는 API")
+@Tag(name = "GPT 레시피 생성", description = "GPT 파싱 → 레시피/재료/단계 일괄 저장 API")
 public class GptRecipeController {
 
     private final GptRecipeService gptRecipeService;
 
-    @Operation(summary = "rawRecipe 텍스트로 GPT 파싱 후 레시피/재료/단계 일괄 저장")
+    @Operation(summary = "rawRecipe 텍스트로 GPT 파싱 후 레시피 전체 저장")
     @PostMapping("/save")
     public RecipeResponseDto saveRecipe(
             @RequestParam Long memberId,

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/dto/RecipeParseResultDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/dto/RecipeParseResultDto.java
@@ -12,7 +12,8 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class IngredientAndRecipeDto {
+public class RecipeParseResultDto {
+    private String title;
     private List<IngredientDto> ingredients;
     private List<RecipeStepDto> steps;
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
@@ -4,9 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sejong.capston.yechef.domain.Gpt.dto.IngredientAndRecipeDto;
-import sejong.capston.yechef.domain.Ingredient.Ingredient;
-import sejong.capston.yechef.domain.Ingredient.repository.IngredientRepository;
+import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Ingredient.service.IngredientService;
 import sejong.capston.yechef.domain.Member.Member;
 import sejong.capston.yechef.domain.Member.repository.MemberRepository;
@@ -16,8 +14,6 @@ import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeResponseDto;
 import sejong.capston.yechef.domain.Recipe.dto.SaveRecipeRequest;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
-import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
-import sejong.capston.yechef.domain.RecipeSteps.repository.RecipeStepRepository;
 import sejong.capston.yechef.domain.RecipeSteps.service.RecipeStepService;
 import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
@@ -36,27 +32,28 @@ public class GptRecipeService {
     private final MemberRecipeRepository memberRecipeRepository;
 
     @Transactional
-    public RecipeResponseDto createFromRaw(Long memberId, String rawRecipe, SaveRecipeRequest request) {
-        // 회원 조회
+    public RecipeResponseDto createFromRaw(
+            Long memberId,
+            String rawRecipe,
+            SaveRecipeRequest request
+    ) {
+        // 회원 확인
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
 
-        // GPT로 파싱
-        IngredientAndRecipeDto recipeDtoToSave = gptService.parseRecipe(rawRecipe);
+        // GPT로 파싱 (제목, 재료, 단계)
+        RecipeParseResultDto parsed = gptService.parseRecipe(rawRecipe);
 
-        // Recipe 엔티티 저장
-        Recipe recipe = Recipe.of(request.getTitle(), member.getNickname(), request.getRecipeType());
+        // Recipe 저장
+        Recipe recipe = Recipe.of(parsed.getTitle(), member.getNickname(), request.getRecipeType());
         recipeRepository.save(recipe);
 
-        // MemberRecipe 연결 저장
-        MemberRecipe memberRecipe = new MemberRecipe(member, recipe);
-        memberRecipeRepository.save(memberRecipe);
+        // MemberRecipe 저장
+        memberRecipeRepository.save(new MemberRecipe(member, recipe));
 
-        // Ingredient 저장
-        ingredientService.saveIngredients(recipeDtoToSave.getIngredients(), recipe);
-
-        // RecipeStep 저장
-        recipeStepService.saveSteps(recipeDtoToSave.getSteps(), recipe);
+        // Ingredient / RecipeStep 저장
+        ingredientService.saveIngredients(parsed.getIngredients(), recipe);
+        recipeStepService.saveSteps(parsed.getSteps(), recipe);
 
         return RecipeResponseDto.from(recipe);
     }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
@@ -25,73 +25,72 @@ public class GptService {
     @Value("${OPENAI_API_URL}")    private String    apiUrl;
     private final ObjectMapper      objectMapper = new ObjectMapper();
 
-    public IngredientAndRecipeDto parseRecipe(String rawRecipe) {
-        // system 프롬프트: 출력 포맷을 JSON 스키마로 고정
+    public RecipeParseResultDto parseRecipe(String rawRecipe) {
         String systemPrompt = """
-                You are a recipe‐parser bot.
-                 ◆ INPUT : A free-form Korean recipe text that contains both ingredients and cooking instructions.
-                 ◆ OUTPUT : (MUST be valid **pure JSON**, no markdown code-block, no extra keys) 
-                 {
-                   "ingredients": [
-                     { "name": "<재료명>", "quantity": "<수량 또는 계량 단위>" },
-                     …
-                   ],
-                   "steps": [
-                     { "order": 1, "action": "<단일 행위>", "description": "<상세 설명(어떤 재료를 어떻게 하는지)>" },
-                     …
-                   ]
-                 }
-                 
-                 ▣ Rules for steps 
-                 1. Split the recipe into the smallest practical cooking actions.
-                    - 한 줄에 여러 행동(자르고 볶는다)이 나오면 반드시 분리한다. 
-                 2. action 값은 _짧은 한국어 동사/동사구_만 기재한다. (예: "떡 준비", "오뎅 자르기", "소세지 칼집", "계란 삶기", "우유 붓기", "6분 끓이기", "치즈 넣기")
-                    - 명사·부가어구(“재료 손질”, “양념 준비”) 같은 포괄적 표현은 사용하지 않는다. 
-                 3. description 에는 대상 재료·온도·시간 등 세부 정보를 풀어서 적는다. 
-                 4. 번호(order)는 1부터 순차적으로 증가한다. 
-                 5. 출력은 오직 JSON 하나! (앞뒤 설명, json 블록, 태그 모두 금지)
-                
+        너는 레시피 파서를 수행하는 AI야.
+        
+        ◆ 입력: 재료와 요리 과정을 포함한 자유 형식의 한국어 요리 레시피 텍스트
+        ◆ 출력: 아래 JSON 형식에 맞춘 **순수 JSON 데이터만** 출력 (마크다운, 설명 문구, 주석 모두 금지)
+        
+        {
+          "title": "<요리명>",                     ← 제목이 명시되어 있지 않으면, 재료와 과정을 참고해 추정해서 작성하세요.
+          "ingredients": [
+            { "name": "<재료명>", "quantity": "<수량 또는 계량 단위>" },
+            …
+          ],
+          "steps": [
+            { "stepNumber": 1, "action": "<단일 행위>", "description": "<상세 설명>" },
+            …
+          ]
+        }
+        
+        ▣ 출력 규칙
+        1. steps는 문장을 가장 작은 단위의 실제 행동 단위로 쪼개서 작성합니다. (예: "자르고 볶는다" → "자르기", "볶기"로 나누기)
+        2. action 값은 짧은 한국어 동사 또는 동사구여야 합니다. (예: "떡 준비", "칼집 넣기")
+        3. description에는 어떤 재료를 어떻게 다루는지, 시간, 온도 등 구체 정보를 포함합니다.
+        4. stepNumber는 1부터 시작하여 순차적으로 증가합니다.
+        5. 출력은 반드시 JSON만 포함되도록 하세요. 설명이나 마크다운 블록 없이 반환합니다.
         """;
 
-        // messages 준비
-        List<Message> messages = List.of(
-                new Message("system", systemPrompt),
-                new Message("user", rawRecipe)
+        // GPT 호출
+        List<sejong.capston.yechef.domain.Gpt.dto.Message> messages = List.of(
+                new sejong.capston.yechef.domain.Gpt.dto.Message("system", systemPrompt),
+                new sejong.capston.yechef.domain.Gpt.dto.Message("user", rawRecipe)
         );
         ChatGPTRequest req = new ChatGPTRequest(model, messages);
         ChatGPTResponse resp = restTemplate.postForObject(apiUrl, req, ChatGPTResponse.class);
         String content = resp.getChoices().get(0).getMessage().getContent().trim();
 
-        // JsonNode로 파싱해서 DTO로 직접 매핑
         try {
             JsonNode root = objectMapper.readTree(content);
 
-            // ingredients 배열 추출
+            // 제목
+            String title = root.path("title").asText("");
+
+            // 재료
             List<IngredientDto> ingredients = new ArrayList<>();
             for (JsonNode ingNode : root.path("ingredients")) {
-                String name     = ingNode.path("name").asText("");
-                String quantity = ingNode.path("quantity").asText("");
-                ingredients.add(new IngredientDto(name, quantity));
+                ingredients.add(new IngredientDto(
+                        ingNode.path("name").asText(""),
+                        ingNode.path("quantity").asText("")
+                ));
             }
 
-            // steps 배열 추출
+            // 단계
             List<RecipeStepDto> steps = new ArrayList<>();
             for (JsonNode stepNode : root.path("steps")) {
-                int    order       = stepNode.path("order").asInt(0);
-                String action      = stepNode.path("action").asText("");
-                String description = stepNode.path("description").asText("");
                 steps.add(RecipeStepDto.builder()
-                        .stepNumber(order)
-                        .action(action)
-                        .description(description)
+                        .stepNumber(stepNode.path("order").asInt(0))
+                        .action(stepNode.path("action").asText(""))
+                        .description(stepNode.path("description").asText(""))
                         .build()
                 );
             }
 
-            return new IngredientAndRecipeDto(ingredients, steps);
+            return new RecipeParseResultDto(title, ingredients, steps);
 
         } catch (JsonProcessingException e) {
-            log.error("GPT 응답 내용을 파싱하는 데 실패했습니다.: {}", content, e);
+            log.error("GPT 응답 파싱 실패 → content: {}", content, e);
             throw BaseException.from(ErrorCode.GPT_RESPONSE_PARSING_FAILED);
         }
     }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -30,14 +30,9 @@ public class RecipeService {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
 
-    Recipe recipe = Recipe.builder()
-        .title(dto.getTitle())
-        .author(member.getNickname())
-        .likeCount(0)
-        .ranking(0.0)
-        .recipeType(dto.getRecipeType())
-        .isUpdated(false)
-        .build();
+    Recipe recipe = Recipe.of(dto.getTitle(),
+            member.getNickname(),
+            dto.getRecipeType());
     recipeRepository.save(recipe);
 
     MemberRecipe memberRecipe = new MemberRecipe(member, recipe);


### PR DESCRIPTION
# 이슈
- #6 

# 구현 기능
- GPT 응답 JSON에 title 필드 추가하여 파싱후 레시피 제목까지 함께 저장
- Recipe 생성 빌더 로직 of 메서드로 정리
- 레시피 정보 dto 이름 리팩토링 -> RecipeParseResultDto
- 
# 작업 시간
