### PR TITLE
[feat] 유효 음식 이미지 필터링 로직 추가 (쇼핑/썸네일/SVG 제외)

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
@@ -14,6 +14,9 @@ public class KakaoImageService {
 
   private final WebClient kakaoImageWebClient;
 
+  /**
+   * 카카오 이미지 검색 API 호출
+   */
   public KakaoImageResponseDto searchImage(String query) {
     try {
       return kakaoImageWebClient.get()
@@ -22,23 +25,49 @@ public class KakaoImageService {
               .queryParam("query", query)
               .queryParam("sort", "accuracy")
               .queryParam("page", 1)
-              .queryParam("size", 3) // 여러 개 받고 싶으면 size 늘리기
+              .queryParam("size", 10) // 여러 개 받아서 필터링
               .build())
           .retrieve()
           .bodyToMono(KakaoImageResponseDto.class)
           .block();
-    }catch (WebClientResponseException e) {
+    } catch (WebClientResponseException e) {
       throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "카카오 이미지 API 응답 오류: " + e.getStatusCode());
     } catch (Exception e) {
       throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "카카오 이미지 API 호출 실패: " + e.getMessage());
     }
   }
 
+  /**
+   * 검색 키워드를 보강하고, 필터링된 이미지 중 가장 상단 URL 반환
+   */
   public String getTopImageUrl(String keyword) {
-    KakaoImageResponseDto response = searchImage(keyword);
-    if (response.getDocuments().isEmpty()) {
-      throw BaseException.from(ErrorCode.KAKAO_API_ERROR, "이미지 검색 결과가 없습니다.");
-    }
-    return response.getDocuments().get(0).getImageUrl();
+    String enhancedQuery = keyword; // 키워드 보강 가능
+
+    KakaoImageResponseDto response = searchImage(enhancedQuery);
+
+    return response.getDocuments().stream()
+        .filter(doc -> isValidImage(doc.getSiteName(), doc.getImageUrl()))
+        .findFirst()
+        .map(KakaoImageResponseDto.Document::getImageUrl)
+        .orElseThrow(() -> BaseException.from(ErrorCode.KAKAO_API_ERROR, "유효한 음식 이미지가 없습니다."));
+  }
+
+  /**
+   * 유효 이미지 필터링 기준:
+   * - 쇼핑몰/블로그/스마트스토어 등 상업적 이미지 제외
+   * - 썸네일 또는 텍스트 이미지 URL 제거
+   */
+  private boolean isValidImage(String siteName, String imageUrl) {
+    if (siteName == null || imageUrl == null) return false;
+
+    String lowerSite = siteName.toLowerCase();
+    String lowerUrl = imageUrl.toLowerCase();
+
+    return !lowerSite.contains("blog")
+        && !lowerSite.contains("쇼핑")
+        && !lowerUrl.contains("smartstore")
+        && !lowerUrl.contains("shopping")
+        && !lowerUrl.contains("thumbnail")
+        && !lowerUrl.endsWith(".svg"); // 아이콘, 벡터 이미지 제거
   }
 }


### PR DESCRIPTION
# 이슈
- 카카오 이미지 검색 시 상업용, 텍스트, 아이콘 이미지가 섞여서 결과 품질 저하

# 구현 기능
- displaySiteName 및 imageUrl 기반 유효 이미지 필터링
  - 쇼핑몰, 블로그, 스마트스토어, 썸네일, SVG 아이콘 제외
- getTopImageUrl에 필터 적용