### PR TITLE
[feat] 대표 이미지 1건 조회용 API(/api/images/top) 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/controller/KakaoImageController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/controller/KakaoImageController.java
@@ -2,10 +2,7 @@ package sejong.capston.yechef.domain.KakaoImage.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sejong.capston.yechef.domain.KakaoImage.dto.KakaoImageResponseDto;
 import sejong.capston.yechef.domain.KakaoImage.service.KakaoImageService;
 
@@ -16,9 +13,21 @@ public class KakaoImageController {
 
   private final KakaoImageService kakaoImageService;
 
+  /**
+   * 전체 이미지 목록 반환 (원본 그대로 전달)
+   */
   @GetMapping
   public ResponseEntity<KakaoImageResponseDto> search(@RequestParam String query) {
     KakaoImageResponseDto result = kakaoImageService.searchImage(query);
     return ResponseEntity.ok(result);
+  }
+
+  /**
+   * 필터링된 대표 이미지 1개만 반환
+   */
+  @GetMapping("/top")
+  public ResponseEntity<String> getTopImage(@RequestParam String query) {
+    String imageUrl = kakaoImageService.getTopImageUrl(query);
+    return ResponseEntity.ok(imageUrl);
   }
 }


### PR DESCRIPTION
# 이슈
- 프론트에서 썸네일 용도로 단일 대표 이미지 URL만 필요함
- 기존 전체 이미지 목록 응답은 과도하게 큼

# 구현 기능
- GET /api/images/top?query=음식이름 엔드포인트 추가
- 필터링 후 유효한 이미지 1개만 반환