### PR TITLE
[feat] 공개 레시피 조회 기능 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -1,9 +1,11 @@
 package sejong.capston.yechef.domain.Recipe.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.service.RecipeService;
@@ -38,5 +40,10 @@ public class RecipeController {
     return ResponseEntity.noContent().build();
   }
 
+  @GetMapping("/public")
+  public ResponseEntity<List<Recipe>> getPublicRecipes() {
+    List<Recipe> publicRecipes = recipeService.getPublicRecipes();
+    return ResponseEntity.ok(publicRecipes);
+  }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/repository/RecipeRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.Recipe.RecipeType;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
   @Query("SELECT r FROM Recipe r JOIN r.memberRecipes mr WHERE mr.member.id = :memberId")
   List<Recipe> findByMemberId(@Param("memberId") Long memberId);
 
+  List<Recipe> findByRecipeType(RecipeType recipeType);
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -101,5 +101,8 @@ public class RecipeService {
         .collect(Collectors.toList());
   }
 
+  public List<Recipe> getPublicRecipes() {
+    return recipeRepository.findByRecipeType(Recipe.RecipeType.PUBLIC);
+  }
 
 }


### PR DESCRIPTION
# 이슈
- [공개 레시피 조회 기능 구현]

# 구현 기능
- `RecipeRepository`: `findByRecipeType(RecipeType recipeType)` 메서드 추가
- `RecipeService`: `getPublicRecipes()` 메서드 구현
- 공개 레시피만 조회 가능하도록 enum 필터 기반으로 동작