### PR TITLE
Feat/recipe image upload 레시피 이미지 처리 통합 및 자동화 기능 구현

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptRecipeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sejong.capston.yechef.domain.Image.service.ImageService;
 import sejong.capston.yechef.domain.Ingredient.service.IngredientService;
 import sejong.capston.yechef.domain.Member.Member;
 import sejong.capston.yechef.domain.Member.repository.MemberRepository;
@@ -29,28 +30,37 @@ public class GptRecipeService {
     private final RecipeRepository recipeRepository;
     private final MemberRepository memberRepository;
     private final MemberRecipeRepository memberRecipeRepository;
+    private final ImageService imageService; // ✅ 썸네일 생성용
+
     @Transactional
     public RecipeResponseDto saveMyNewRecipe(
-            Long memberId,
-            SaveRecipeRequest request
+        Long memberId,
+        SaveRecipeRequest request
     ) {
-        // 회원 확인
+        // 1. 회원 확인
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
 
-        // Recipe 저장
-        Recipe recipe = Recipe.of(request.getTitle(), member.getNickname(), Recipe.RecipeType.PRIVATE);
+        // 2. Recipe 저장 (sourceImage는 GPT라서 null)
+        Recipe recipe = Recipe.of(
+            request.getTitle(),
+            member.getNickname(),
+            Recipe.RecipeType.PRIVATE,
+            null
+        );
         recipeRepository.save(recipe);
 
-        // MemberRecipe
+        // 3. 썸네일 자동 생성
+        imageService.generateAndSaveThumbnail(recipe.getId());
+
+        // 4. MemberRecipe 연결
         MemberRecipe memberRecipe = MemberRecipe.of(member, recipe);
         memberRecipeRepository.save(memberRecipe);
 
-        // Ingredient / RecipeStep 저장
+        // 5. Ingredient / RecipeStep 저장
         ingredientService.saveIngredients(request.getIngredients(), recipe);
         recipeStepService.saveSteps(request.getSteps(), recipe);
 
         return RecipeResponseDto.from(recipe);
     }
-
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
@@ -11,11 +11,18 @@ import sejong.capston.yechef.domain.Recipe.Recipe;
 @Builder
 public class Image {
 
-  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private String s3Url;
+  private String s3Key; // ← 키는 동적으로 외부에서 생성해서 주입해야 함
 
   @OneToOne(fetch = FetchType.LAZY)
   private Recipe recipe;
+
+  public Image(String s3Url, String s3Key) {
+    this.s3Url = s3Url;
+    this.s3Key = s3Key;
+  }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/controller/ImageController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/controller/ImageController.java
@@ -18,7 +18,7 @@ public class ImageController {
 
   @PostMapping("/generate")
   public ResponseEntity<Void> generate(@RequestParam Long recipeId) {
-    imageService.generateAndSaveImageForRecipe(recipeId);
+    imageService.generateAndSaveThumbnail(recipeId); // ← 정확한 메서드명으로 수정
     return ResponseEntity.ok().build();
   }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
@@ -20,19 +20,30 @@ public class ImageService {
   private final KakaoImageService kakaoImageService;
 
   @Transactional
-  public void generateAndSaveImageForRecipe(Long recipeId) {
+  public void generateAndSaveThumbnail(Long recipeId) {
     Recipe recipe = recipeRepository.findById(recipeId)
-        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST, "해당 레시피가 존재하지 않습니다."));
+        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
 
     String imageUrl = kakaoImageService.getTopImageUrl(recipe.getTitle());
+    String s3Key = extractKeyFromUrl(imageUrl); // 외부 URL이면 null
 
-    Image image = Image.builder()
+    Image thumbnailImage = Image.builder()
         .s3Url(imageUrl)
+        .s3Key(s3Key)
         .recipe(recipe)
         .build();
 
-    imageRepository.save(image);
-
-    recipe.setImage(image);
+    imageRepository.save(thumbnailImage);
+    recipe.setThumbnailImage(thumbnailImage);
   }
+
+
+  private String extractKeyFromUrl(String url) {
+    // Kakao URL이면 key가 없는 외부 이미지일 수도 있음
+    if (url == null || !url.contains(".amazonaws.com/")) return null;
+
+    // ex: https://bucket-name.s3.region.amazonaws.com/source-images/abc.jpg
+    return url.substring(url.indexOf(".com/") + 5);
+  }
+
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
@@ -53,8 +53,11 @@ public class Recipe extends BaseEntity {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<MemberRecipe> memberRecipes = new ArrayList<>();
 
-    @OneToOne(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private Image image;
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Image thumbnailImage;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Image sourceImage;
 
     @Builder
     public Recipe(
@@ -64,7 +67,8 @@ public class Recipe extends BaseEntity {
             String author,
             double ranking,
             RecipeType recipeType,
-            boolean isUpdated
+            boolean isUpdated,
+            Image sourceImage
     ) {
         this.id = id;
         this.title = title;
@@ -73,10 +77,11 @@ public class Recipe extends BaseEntity {
         this.ranking = ranking;
         this.recipeType = recipeType;
         this.isUpdated = isUpdated;
+        this.sourceImage = sourceImage;
     }
 
     // 새 레시피 생성
-    public static Recipe of(String title, String author, RecipeType recipeType) {
+    public static Recipe of(String title, String author, RecipeType recipeType, Image sourceImage) {
         return Recipe.builder()
                 .title(title)
                 .author(author)
@@ -84,6 +89,7 @@ public class Recipe extends BaseEntity {
                 .ranking(0.0)
                 .recipeType(recipeType)
                 .isUpdated(false)
+                .sourceImage(sourceImage)
                 .build();
     }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -2,9 +2,11 @@ package sejong.capston.yechef.domain.Recipe.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeCreateDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
@@ -18,12 +20,13 @@ public class RecipeController {
 
   private final RecipeService recipeService;
 
-  @PostMapping
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public RecipeDto createRecipe(
       @AuthenticationPrincipal LoginMemberDto user,
-      @RequestBody RecipeCreateDto dto
+      @RequestPart("data") RecipeCreateDto dto,
+      @RequestPart("sourceImage") MultipartFile sourceImageFile
   ) {
-    return recipeService.create(user.getId(), dto);
+    return recipeService.create(user.getId(), dto, sourceImageFile);
   }
 
   @GetMapping("/{recipeId}")
@@ -45,5 +48,4 @@ public class RecipeController {
     List<Recipe> publicRecipes = recipeService.getPublicRecipes();
     return ResponseEntity.ok(publicRecipes);
   }
-
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
@@ -14,6 +14,9 @@ public class RecipeDto {
   private String author;
   private Recipe.RecipeType recipeType;
   private int likeCount;
+  private String thumbnailImageUrl;
+  private String sourceImageUrl;
+
 
   public static RecipeDto from(Recipe recipe) {
     return RecipeDto.builder()
@@ -22,6 +25,8 @@ public class RecipeDto {
         .author(recipe.getAuthor())
         .recipeType(recipe.getRecipeType())
         .likeCount(recipe.getLikeCount())
+        .thumbnailImageUrl(recipe.getThumbnailImage() != null ? recipe.getThumbnailImage().getS3Url() : null)
+        .sourceImageUrl(recipe.getSourceImage() != null ? recipe.getSourceImage().getS3Url() : null)
         .build();
   }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -6,6 +6,11 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import sejong.capston.yechef.domain.Image.Image;
+import sejong.capston.yechef.domain.Image.repository.ImageRepository;
+import sejong.capston.yechef.domain.Image.service.ImageService;
+import sejong.capston.yechef.domain.KakaoImage.service.KakaoImageService;
 import sejong.capston.yechef.domain.Member.Member;
 import sejong.capston.yechef.domain.Member.repository.MemberRepository;
 import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
@@ -16,6 +21,7 @@ import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
 import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
+import sejong.capston.yechef.global.s3.service.S3UploadService;
 
 @Service
 @RequiredArgsConstructor
@@ -24,24 +30,33 @@ public class RecipeService {
   private final RecipeRepository recipeRepository;
   private final MemberRepository memberRepository;
   private final MemberRecipeRepository memberRecipeRepository;
+  private final ImageService imageService;
+  private final ImageRepository imageRepository;
+  private final S3UploadService s3UploadService;
 
   @Transactional
-  public RecipeDto create(Long memberId, RecipeCreateDto dto) {
+  public RecipeDto create(Long memberId, RecipeCreateDto dto, MultipartFile sourceImageFile) {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
 
-    Recipe recipe = Recipe.of(dto.getTitle(),
-            member.getNickname(),
-            dto.getRecipeType());
+    // 1. 업로드 및 URL 획득 (키 생성 포함)
+    String s3Url = s3UploadService.uploadAndGenerateKey(sourceImageFile);
+    String s3Key = s3UploadService.extractKeyFromUrl(s3Url); // url → key 저장용 (아래 참고)
+
+    // 2. 이미지 저장
+    Image sourceImage = imageRepository.save(Image.builder()
+        .s3Url(s3Url)
+        .s3Key(s3Key)
+        .build());
+
+    // 3. 레시피 저장
+    Recipe recipe = Recipe.of(dto.getTitle(), member.getNickname(), dto.getRecipeType(), sourceImage);
     recipeRepository.save(recipe);
 
-    MemberRecipe memberRecipe = MemberRecipe.builder()
-        .member(member)
-        .recipe(recipe)
-        .isOwner(true)
-        .isLiked(false)
-        .build();
-    memberRecipeRepository.save(memberRecipe);
+    imageService.generateAndSaveThumbnail(recipe.getId());
+
+    // 4. 사용자와 연결
+    memberRecipeRepository.save(MemberRecipe.of(member, recipe));
 
     return RecipeDto.from(recipe);
   }
@@ -63,7 +78,19 @@ public class RecipeService {
   public void delete(Long memberId, Long recipeId) {
     MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
         .orElseThrow(() -> BaseException.from(ErrorCode.NOT_RECIPE_OWNER));
-    recipeRepository.delete(memberRecipe.getRecipe());
+
+    Recipe recipe = memberRecipe.getRecipe();
+
+    // 1. 썸네일 이미지 삭제
+    if (recipe.getThumbnailImage() != null) {
+      s3UploadService.deleteFile(recipe.getThumbnailImage().getS3Key());
+    }
+    // 2. 사용자 원본 이미지 삭제
+    if (recipe.getSourceImage() != null) {
+      s3UploadService.deleteFile(recipe.getSourceImage().getS3Key());
+    }
+    // 3. 레시피 삭제 (Image는 cascade + orphanRemoval로 자동 삭제됨)
+    recipeRepository.delete(recipe);
   }
 
   @Transactional

--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
     //s3
     FILE_UPLOAD_FAIL("S3-001", "파일 업로드에 실패했습니다.", ErrorDisplayType.TOAST),
+    FILE_DELETE_FAIL("S3-002", "파일 삭제에 실패했습니다.", ErrorDisplayType.TOAST),
 
     // kakao img api
     KAKAO_API_ERROR("K-001", "카카오 이미지 검색 중 오류 발생", ErrorDisplayType.TOAST)

--- a/yechef/src/main/java/sejong/capston/yechef/global/s3/service/S3UploadService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/s3/service/S3UploadService.java
@@ -14,6 +14,7 @@ import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -67,4 +68,54 @@ public class S3UploadService {
         .build());
     return url;
   }
+
+  public void deleteFile(String s3Key) {
+    try {
+      DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+          .bucket(bucketName)
+          .key(s3Key)
+          .build();
+      s3Client.deleteObject(deleteObjectRequest);
+
+    } catch (Exception e) {
+      throw BaseException.from(ErrorCode.FILE_DELETE_FAIL, e.getMessage());
+    }
+  }
+
+  public String uploadWithKey(MultipartFile file, String fileKey) {
+    String fileUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + fileKey;
+
+    try (InputStream inputStream = file.getInputStream()) {
+      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+          .bucket(bucketName)
+          .key(fileKey)
+          .contentType(file.getContentType())
+          .acl(ObjectCannedACL.PUBLIC_READ)
+          .build();
+
+      s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, file.getSize()));
+
+      return fileUrl;
+
+    } catch (IOException e) {
+      throw BaseException.from(ErrorCode.FILE_UPLOAD_FAIL, "파일 업로드 중 IO 오류: " + e.getMessage());
+    } catch (Exception e) {
+      throw BaseException.from(ErrorCode.FILE_UPLOAD_FAIL, "파일 업로드 실패: " + e.getMessage());
+    }
+  }
+
+  public String uploadAndGenerateKey(MultipartFile file) {
+    String key = generateS3Key(file);
+    return uploadWithKey(file, key); // 내부 재사용
+  }
+
+  private String generateS3Key(MultipartFile file) {
+    return "source-images/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+  }
+
+  public String extractKeyFromUrl(String url) {
+    if (url == null || !url.contains(".amazonaws.com/")) return null;
+    return url.substring(url.indexOf(".com/") + 5);
+  }
+
 }


### PR DESCRIPTION
# 이슈
- [레시피 이미지 처리 통합 및 자동화 기능 구현]

# 구현 기능
- S3 이미지 업로드 시 키 지정 및 삭제 기능 추가 (`S3UploadService`)
- 레시피 생성 시 이미지 등록 로직 연동 (`RecipeService`)
- 멀티파트 요청 처리 및 이미지 포함 DTO 반영 (`RecipeController`)
- 이미지 및 파일 삭제 실패 예외 처리 추가 (`ErrorCode`)
- GPT 기반 자동 생성 레시피에 썸네일 자동 등록 (`GptRecipeService`, `ImageService`)
- 썸네일 저장 책임 분리 (`ImageService` → Kakao 이미지 API 연동)

