### PR TITLE
[feat] 레시피 및 이미지 API 임시 인증 해제

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                         "/bot", "/bot/**",  // gpt api
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
-                        "/api/images"
+                        "/api/images",
+                        "/api/recipes/**"
                 ).permitAll()
 
 


### PR DESCRIPTION
# 이슈
- API 테스트 및 프론트 통합을 위한 임시 인증 해제 조치

# 구현 기능
- Spring Security 설정에서 `/api/recipes/**`, `/api/images` 경로에 대해 `permitAll()` 적용
- JWT 없이도 레시피 생성 및 이미지 요청 가능하도록 수정
- 추후 배포 전 인증 복구 필요 (보안 주의)