### PR TITLE
[feat] nickname 으로 memberId 조회 기능 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/Member.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/Member.java
@@ -19,7 +19,8 @@ public class Member extends BaseEntity {
   private Long id;
 
   @NonNull private String nickname;
-  @NonNull private Long oauthId;
+  // 개발용 임시 제거 @NotNull private Long oauthId;
+  private Long oauthId;
   @Column(unique = true) private String email;
   private boolean showExamplePhoto = true;
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/controller/MemberController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/controller/MemberController.java
@@ -27,10 +27,17 @@ public class MemberController {
     return ResponseEntity.created(URI.create("/api/users/" + result.getId())).body(result);
   }
 
-  @Operation(summary = "회원 정보 조회")
+  @Operation(summary = "회원 정보 id로 조회")
   @GetMapping("/{memberId}")
   public ResponseEntity<MemberDto> getMemberInfo(@PathVariable("memberId") Long memberId) {
     MemberDto memberDto = memberService.getMemberInfo(memberId);
+    return ResponseEntity.ok(memberDto);
+  }
+
+  @Operation(summary = "회원 정보 nickname으로 조회")
+  @GetMapping("/nickname/{nickname}")
+  public ResponseEntity<MemberDto> getMemberIdFromName(@PathVariable("nickname") String nickname) {
+    MemberDto memberDto = memberService.getMemberId(nickname);
     return ResponseEntity.ok(memberDto);
   }
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/repository/MemberRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Member findByOauthId(Long oauthId);
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByNickname(String nickname);
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Member/service/MemberService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Member/service/MemberService.java
@@ -42,6 +42,16 @@ public class MemberService {
   }
 
   @Transactional
+  public MemberDto getMemberId(String nickname) {
+    Member member = memberRepository.findByNickname(nickname)
+            .orElseThrow(() -> {
+              log.error("회원 조회 실패: name: {}", nickname);
+              return BaseException.from(ErrorCode.MEMBER_NOT_FOUND);
+            });
+    return toDto(member);
+  }
+
+  @Transactional
   public MemberDto updateMember(Long memberId, MemberUpdateDto updateDto) {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
# 이슈
- memberId 조회를 위한 메서드의 부재로 memberId 값 조회 불가 이슈

# 구현 기능
- nickname 으로 memberId 조회 기능 추가
- /api/users/nickname/{nickname} 엔드포인트 추가

# 작업 시간
