### PR TITLE
[refactor] 레시피 생성 시 파라메터로 받는 dto 문자열 직접 파싱하도록 구조 변경

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -3,6 +3,7 @@ package sejong.capston.yechef.domain.Recipe.controller;
 import java.net.URI;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
@@ -28,24 +29,34 @@ import sejong.capston.yechef.domain.Recipe.service.RecipeService;
 public class RecipeController {
 
   private final RecipeService recipeService;
-  @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<RecipeDto> createRecipe(
-          @Parameter(description = "회원 ID", required = true)
-          @PathVariable Long memberId,
+    @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<RecipeDto> createRecipe(
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId,
 
-          @Parameter(description = "GPT 파싱 결과 JSON", required = true)
-          @RequestPart("dto") RecipeParseResultDto dto,
+            @Parameter(description = "GPT 파싱 결과 JSON (문자열 형태)", required = true)
+            @RequestPart("dto") String dtoText,  // String으로 먼저 받음
 
-          @Parameter(description = "레시피 이미지 파일", required = true)
-          @RequestPart("sourceImageFile") MultipartFile sourceImageFile
-  ) {
-    RecipeDto result = recipeService.create(memberId, dto, sourceImageFile);
-    return ResponseEntity
-            .created(URI.create("/api/recipes/" + result.getId()))
-            .body(result);
-  }
+            @Parameter(description = "레시피 이미지 파일", required = true)
+            @RequestPart("sourceImageFile") MultipartFile sourceImageFile
+    ) {
+        try {
+            // 문자열 → 객체 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            RecipeParseResultDto dto = objectMapper.readValue(dtoText, RecipeParseResultDto.class);
 
-  @GetMapping("/{recipeId}")
+            RecipeDto result = recipeService.create(memberId, dto, sourceImageFile);
+            return ResponseEntity
+                    .created(URI.create("/api/recipes/" + result.getId()))
+                    .body(result);
+        } catch (Exception e) {
+            // 파싱 실패 시 예외 처리
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+
+    @GetMapping("/{recipeId}")
   public ResponseEntity<RecipeDto> getRecipe(
           @Parameter(description = "조회할 레시피 ID", required = true)
           @PathVariable Long recipeId


### PR DESCRIPTION
> 아래 요소들은 모두 채워주고 추가적인 제목은 자유롭게 작성하면 됩니다. (지워주세요)
# 이슈
- #6 

# 구현 기능
- 레시피 생성 시 파라메터로 받는 dto 문자열(json) 직접 파싱하도록 구조 변경

# 작업 시간
