### PR TITLE
[fix] 외부 이미지 썸네일 삭제 시 S3 오류 방지

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -106,8 +106,12 @@ public class RecipeService {
 
     // 1. 썸네일 이미지 삭제
     if (recipe.getThumbnailImage() != null) {
-      s3UploadService.deleteFile(recipe.getThumbnailImage().getS3Key());
+      String thumbnailKey = recipe.getThumbnailImage().getS3Key();
+      if (thumbnailKey != null) {
+        s3UploadService.deleteFile(thumbnailKey);
+      }
     }
+    
     // 2. 사용자 원본 이미지 삭제
     if (recipe.getSourceImage() != null) {
       s3UploadService.deleteFile(recipe.getSourceImage().getS3Key());


### PR DESCRIPTION
# 이슈
- [썸네일 이미지 삭제 시 S3 오류 발생]

# 구현 기능
- RecipeService.delete()에서 썸네일 이미지 삭제 시 s3Key가 null이면 삭제 생략
- Kakao 이미지 기반 외부 썸네일 대응
- deleteFile() 호출 전에 s3Key 유효성 검사 추가
- 원본 이미지는 기존과 동일하게 삭제 유지