### PR TITLE
[feat] 멤버별 레시피 및 좋아요 레시피 조회 기능 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/controller/MemberRecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/controller/MemberRecipeController.java
@@ -1,5 +1,6 @@
 package sejong.capston.yechef.domain.MemberRecipe.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,8 +9,10 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.service.RecipeService;
+import sejong.capston.yechef.global.exception.BaseException;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,23 +23,35 @@ public class MemberRecipeController {
 
   @PatchMapping("/{memberId}/recipes/{recipeId}/like")
   public ResponseEntity<Void> toggleLike(
-      @PathVariable Long memberId,
-      @PathVariable Long recipeId
+      @PathVariable("memberId") Long memberId,
+      @PathVariable("recipeId") Long recipeId
   ) {
     recipeService.toggleLike(memberId, recipeId);
     return ResponseEntity.ok().build();
   }
 
   @GetMapping("/{memberId}/my-recipes")
-  public List<RecipeDto> getMyRecipes(@PathVariable Long memberId) {
+  public List<RecipeDto> getMyRecipes(
+      @Parameter(description = "회원 ID", required = true)
+      @PathVariable("memberId") Long memberId
+  ) {
     return recipeService.getMyRecipes(memberId);
   }
 
   // 향후 확장을 위한 좋아요 목록 예시
   @GetMapping("/{memberId}/likes")
-  public List<RecipeDto> getLikedRecipes(@PathVariable Long memberId) {
+  public List<RecipeDto> getLikedRecipes(
+      @PathVariable("memberId") Long memberId) {
     return recipeService.getLikedRecipes(memberId); // 메서드 직접 구현 필요
   }
+
+  @GetMapping("/member-recipes/{memberRecipeId}/recipe")
+  public ResponseEntity<RecipeDto> getRecipeFromMemberRecipe(
+      @PathVariable("memberRecipeId") Long memberRecipeId
+  ) {
+    return ResponseEntity.ok(recipeService.getRecipeFromMemberRecipe(memberRecipeId));
+  }
+
 }
 
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/repository/MemberRecipeRepository.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/MemberRecipe/repository/MemberRecipeRepository.java
@@ -3,6 +3,8 @@ package sejong.capston.yechef.domain.MemberRecipe.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
 import sejong.capston.yechef.domain.Recipe.Recipe;
 
@@ -10,6 +12,8 @@ public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long
 
   Optional<MemberRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
 
-  List<Recipe> findLikedRecipesByMemberId(Long memberId);
+  @Query("SELECT mr.recipe FROM MemberRecipe mr WHERE mr.member.id = :memberId AND mr.isLiked = true")
+  List<Recipe> findLikedRecipesByMemberId(@Param("memberId") Long memberId);
+
 }
 

--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     NOT_EXIST_THIS_STEP("RCP-0003", "레시피 해당 단계가 존재하지 않습니다.", ErrorDisplayType.POPUP),
     RECIPE_SAVE_FAILED("RCP-0004", "레시피 저장 실패", ErrorDisplayType.POPUP),
 
+    // memberRecipe
+    MEMBER_RECIPE_NOT_FOUND("MRP-0000", "멤버레시피가 존재하지 않습니다.", ErrorDisplayType.POPUP),
+
     //gpt
     GPT_RESPONSE_PARSING_FAILED("GPT-0000", "GPT 응답 파싱에 실패했습니다.", ErrorDisplayType.POPUP),
 


### PR DESCRIPTION
# 이슈
- [멤버별 레시피 및 좋아요 조회 기능 추가]

# 구현 기능
- `/api/member-recipes/{memberId}/my-recipes`  
  → 사용자가 작성한 레시피 목록 조회

- `/api/member-recipes/{memberId}/likes`  
  → 사용자가 좋아요한 레시피 목록 조회

- `/api/member-recipes/{memberRecipeId}/recipe`  
  → memberRecipeId 기준으로 레시피 단건 조회

- `RecipeService`에 조회 메서드 추가  
  (`getMyRecipes`, `getLikedRecipes`, `getRecipeFromMemberRecipe`)

- `MemberRecipeRepository`에 좋아요 필터링 쿼리 추가  
  (`findLikedRecipesByMemberId`)

- `ErrorCode`에 `MEMBER_RECIPE_NOT_FOUND` 항목 추가
