### PR TITLE
[feat] AI OCR 기능 세팅 및 레시피 파싱

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/dto/RecipeParseResultDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/dto/RecipeParseResultDto.java
@@ -18,4 +18,20 @@ public class RecipeParseResultDto {
     private int servings;
     private List<IngredientDto> ingredients;
     private List<RecipeStepDto> steps;
+
+    private String sourceImageUrl;
+
+    public RecipeParseResultDto(    // TODO: 사용처를 빌더 패턴으로 수정하기
+        String title,
+        String text,
+        int servings,
+        List<IngredientDto> ingredients,
+        List<RecipeStepDto> steps
+    ) {
+        this.title = title;
+        this.text = text;
+        this.servings = servings;
+        this.ingredients = ingredients;
+        this.steps = steps;
+    }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/service/ImageService.java
@@ -3,6 +3,7 @@ package sejong.capston.yechef.domain.Image.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import sejong.capston.yechef.domain.Image.Image;
 import sejong.capston.yechef.domain.Image.repository.ImageRepository;
 import sejong.capston.yechef.domain.KakaoImage.service.KakaoImageService;
@@ -10,6 +11,7 @@ import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
 import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
+import sejong.capston.yechef.global.s3.service.S3UploadService;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +20,7 @@ public class ImageService {
   private final ImageRepository imageRepository;
   private final RecipeRepository recipeRepository;
   private final KakaoImageService kakaoImageService;
+  private final S3UploadService s3UploadService;
 
   @Transactional
   public void generateAndSaveThumbnail(Long recipeId) {
@@ -44,6 +47,19 @@ public class ImageService {
 
     // ex: https://bucket-name.s3.region.amazonaws.com/source-images/abc.jpg
     return url.substring(url.indexOf(".com/") + 5);
+  }
+
+  @Transactional
+  public Image saveImage(MultipartFile file) {
+    String s3Url = s3UploadService.uploadAndGenerateKey(file);
+    String s3Key = s3UploadService.extractKeyFromUrl(s3Url);
+
+    Image image = Image.builder()
+        .s3Url(s3Url)
+        .s3Key(s3Key)
+        .build();
+
+    return imageRepository.save(image);
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/KakaoImage/service/KakaoImageService.java
@@ -1,6 +1,7 @@
 package sejong.capston.yechef.domain.KakaoImage.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -12,10 +13,13 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 @Service
-@RequiredArgsConstructor
 public class KakaoImageService {
 
   private final WebClient kakaoImageWebClient;
+
+  public KakaoImageService(@Qualifier("kakaoImageWebClient") WebClient kakaoImageWebClient) {
+    this.kakaoImageWebClient = kakaoImageWebClient;
+  }
 
   /**
    * 카카오 이미지 검색 API 호출

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -3,7 +3,9 @@ package sejong.capston.yechef.domain.Recipe.ai;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 
@@ -18,11 +20,14 @@ public class OcrClient {
   }
 
 
-  public RecipeParseResultDto extractText(String imageUrl) {
+  public RecipeParseResultDto extractText(MultipartFile imageFile) {
+    MultipartBodyBuilder builder = new MultipartBodyBuilder();
+    builder.part("file", imageFile.getResource());
+
     return webClient.post()
         .uri("/ocr/parse")
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Map.of("imageUrl", imageUrl))
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(builder.build())
         .retrieve()
         .bodyToMono(RecipeParseResultDto.class)
         .block();

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -1,4 +1,31 @@
 package sejong.capston.yechef.domain.Recipe.ai;
 
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
+
+@Component
 public class OcrClient {
+
+  @Qualifier("aiWebClient")
+  private final WebClient webClient;
+
+  public OcrClient(@Qualifier("aiWebClient") WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+
+  public RecipeParseResultDto extractText(String imageUrl) {
+    return webClient.post()
+        .uri("/ocr/parse")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(Map.of("imageUrl", imageUrl))
+        .retrieve()
+        .bodyToMono(RecipeParseResultDto.class)
+        .block();
+  }
+
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -1,0 +1,4 @@
+package sejong.capston.yechef.domain.Recipe.ai;
+
+public class OcrClient {
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -40,11 +40,11 @@ public class RecipeController {
         .body(result);
   }
 
-  // OCR용 이미지 업로드
-  @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<RecipeParseResultDto> extractRecipeTextFormImage(
+  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<RecipeDto> createRecipeFromImage(
+      @RequestParam("memberId") Long memberId,
       @RequestPart("image") MultipartFile imageFile) {
-    RecipeParseResultDto result = recipeService.extractTextFromImage(imageFile);
+    RecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
     return ResponseEntity.ok(result);
   }
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -3,19 +3,14 @@ package sejong.capston.yechef.domain.Recipe.controller;
 import java.net.URI;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Recipe.Recipe;
@@ -30,32 +25,30 @@ import sejong.capston.yechef.domain.Recipe.service.RecipeService;
 public class RecipeController {
 
   private final RecipeService recipeService;
-    @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<RecipeDto> createRecipe(
-            @Parameter(description = "회원 ID", required = true)
-            @PathVariable("memberId") Long memberId,
 
-            @Parameter(description = "GPT 파싱 결과 JSON (문자열 형태)", required = true)
-            @RequestPart("dto") String dtoText,  // String으로 먼저 받음
+  // ✅ 레시피 저장 (AI에서 받은 OCR 결과 저장)
+  @PostMapping(value = "/{memberId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<RecipeDto> createRecipe(
+      @Parameter(description = "회원 ID", required = true)
+      @PathVariable("memberId") Long memberId,
 
-            @Parameter(description = "레시피 이미지 파일", required = true)
-            @RequestPart("sourceImageFile") MultipartFile sourceImageFile
-    ) {
-        try {
-            // 문자열 → 객체 변환
-            ObjectMapper objectMapper = new ObjectMapper();
-            RecipeParseResultDto dto = objectMapper.readValue(dtoText, RecipeParseResultDto.class);
+      @RequestBody RecipeParseResultDto dto
+  ) {
+    RecipeDto result = recipeService.create(memberId, dto);
+    return ResponseEntity
+        .created(URI.create("/api/recipes/" + result.getId()))
+        .body(result);
+  }
 
-            RecipeDto result = recipeService.create(memberId, dto, sourceImageFile);
-            return ResponseEntity
-                    .created(URI.create("/api/recipes/" + result.getId()))
-                    .body(result);
-        } catch (Exception e) {
-            // 파싱 실패 시 예외 처리
-            return ResponseEntity.badRequest().build();
-        }
-    }
-    
+  // OCR용 이미지 업로드
+  @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<RecipeParseResultDto> extractRecipeTextFormImage(
+      @RequestPart("image") MultipartFile imageFile) {
+    RecipeParseResultDto result = recipeService.extractTextFromImage(imageFile);
+    return ResponseEntity.ok(result);
+  }
+
+  // 상세 조회
   @GetMapping("/{recipeId}")
   public ResponseEntity<DetailRecipeDto> getRecipe(
       @Parameter(description = "조회할 레시피 ID", required = true)
@@ -64,7 +57,7 @@ public class RecipeController {
     return ResponseEntity.ok(recipeService.getRecipe(recipeId));
   }
 
-
+  // 삭제
   @DeleteMapping("/members/{memberId}/recipes/{recipeId}")
   public ResponseEntity<Void> deleteRecipe(
       @PathVariable("memberId") Long memberId,
@@ -74,7 +67,7 @@ public class RecipeController {
     return ResponseEntity.noContent().build();
   }
 
-
+  // 공개 목록 조회
   @GetMapping("/public")
   public ResponseEntity<List<Recipe>> getPublicRecipes() {
     return ResponseEntity.ok(recipeService.getPublicRecipes());

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeProgressController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeProgressController.java
@@ -2,10 +2,12 @@ package sejong.capston.yechef.domain.Recipe.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeStepDto;
 import sejong.capston.yechef.domain.Recipe.dto.VoiceInputDto;
@@ -18,14 +20,15 @@ public class RecipeProgressController {
 
   private final RecipeProgressService progressService;
 
-  @PostMapping("/{recipeId}/step/{stepNumber}/progress")
+  @GetMapping("/{recipeId}/step/{stepNumber}/progress")
   public RecipeStepDto progressStep(
-      @PathVariable("memberId") Long memberId,
+      @RequestParam("memberId") Long memberId,
       @PathVariable("recipeId") Long recipeId,
       @PathVariable("stepNumber") int stepNumber,
-      @RequestBody VoiceInputDto input
+      @RequestParam("text") String inputText
   ) {
-    return progressService.processStep(memberId, recipeId, stepNumber, input.getText());
+    return progressService.processStep(memberId, recipeId, stepNumber, inputText);
   }
+
 }
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -1,6 +1,6 @@
 package sejong.capston.yechef.domain.Recipe.service;
 
-import jakarta.persistence.EntityNotFoundException;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +17,10 @@ import sejong.capston.yechef.domain.Member.repository.MemberRepository;
 import sejong.capston.yechef.domain.MemberRecipe.MemberRecipe;
 import sejong.capston.yechef.domain.MemberRecipe.repository.MemberRecipeRepository;
 import sejong.capston.yechef.domain.Recipe.Recipe;
+import sejong.capston.yechef.domain.Recipe.ai.OcrClient;
 import sejong.capston.yechef.domain.Recipe.dto.DetailRecipeDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
-import sejong.capston.yechef.domain.Recipe.dto.SaveRecipeRequest;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
-import sejong.capston.yechef.domain.RecipeSteps.repository.RecipeStepRepository;
 import sejong.capston.yechef.domain.RecipeSteps.service.RecipeStepService;
 import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
@@ -40,49 +39,38 @@ public class RecipeService {
   private final S3UploadService s3UploadService;
   private final IngredientService ingredientService;
   private final RecipeStepService recipeStepService;
+  private final OcrClient ocrClient;
 
   @Transactional
-  public RecipeDto create(Long memberId, RecipeParseResultDto recipeDto, MultipartFile sourceImageFile) {
-
-    // 회원 확인
+  public RecipeDto create(Long memberId, RecipeParseResultDto recipeDto) {
     Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+        .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
 
-    // 업로드 및 URL 획득 (키 생성 포함)
-    String s3Url = s3UploadService.uploadAndGenerateKey(sourceImageFile);
+    String s3Url = recipeDto.getSourceImageUrl();
     String s3Key = s3UploadService.extractKeyFromUrl(s3Url);
 
-    // 이미지 저장
     Image sourceImage = imageRepository.save(Image.builder()
-         .s3Url(s3Url)
-         .s3Key(s3Key)
-         .build());
+        .s3Url(s3Url)
+        .s3Key(s3Key)
+        .build());
 
-    // Recipe 저장
     Recipe recipe = Recipe.of(
-            recipeDto.getTitle(),
-            member.getNickname(),
-            Recipe.RecipeType.PRIVATE,
-            recipeDto.getServings(),
-            recipeDto.getText(),
-            sourceImage);
+        recipeDto.getTitle(),
+        member.getNickname(),
+        Recipe.RecipeType.PRIVATE,
+        recipeDto.getServings(),
+        recipeDto.getText(),
+        sourceImage);
     recipeRepository.save(recipe);
 
-    // MemberRecipe 연결
-    MemberRecipe memberRecipe = MemberRecipe.of(member, recipe);
-
-    // Member 연결
-    memberRecipeRepository.save(memberRecipe);
-
-    // Ingredient / RecipeStep 저장
+    memberRecipeRepository.save(MemberRecipe.of(member, recipe));
     ingredientService.saveIngredients(recipeDto.getIngredients(), recipe);
     recipeStepService.saveSteps(recipeDto.getSteps(), recipe);
-
-    // 썸네일 자동 생성
     imageService.generateAndSaveThumbnail(recipe.getId());
 
     return RecipeDto.from(recipe);
   }
+
 
   @Transactional(readOnly = true)
   public List<RecipeDto> getMyRecipes(Long memberId) {
@@ -99,73 +87,52 @@ public class RecipeService {
 
   @Transactional
   public void delete(Long memberId, Long recipeId) {
-    // 1. 현재 사용자의 MemberRecipe 조회
     MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
         .orElseThrow(() -> BaseException.from(ErrorCode.NOT_RECIPE_OWNER));
 
     Recipe recipe = memberRecipe.getRecipe();
-
-    // 2. MemberRecipe 삭제
     memberRecipeRepository.delete(memberRecipe);
 
-    // 3. 해당 recipe가 다른 멤버에게 공유되지 않았다면 실제로 삭제
     long remainingLinks = memberRecipeRepository.countByRecipeId(recipeId);
     if (remainingLinks == 0) {
-      // 3-1. 썸네일 S3 삭제
       if (recipe.getThumbnailImage() != null) {
-        String thumbnailKey = recipe.getThumbnailImage().getS3Key();
-        if (thumbnailKey != null) {
-          s3UploadService.deleteFile(thumbnailKey);
-        }
+        s3UploadService.deleteFile(recipe.getThumbnailImage().getS3Key());
       }
-
-      // 3-2. 원본 이미지 S3 삭제
       if (recipe.getSourceImage() != null) {
-        String sourceKey = recipe.getSourceImage().getS3Key();
-        if (sourceKey != null) {
-          s3UploadService.deleteFile(sourceKey);
-        }
+        s3UploadService.deleteFile(recipe.getSourceImage().getS3Key());
       }
-
-      // 3-3. 레시피 삭제 (Image는 cascade + orphanRemoval)
       recipeRepository.delete(recipe);
     }
   }
 
-
   @Transactional
   public void toggleLike(Long memberId, Long recipeId) {
     Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+        .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
     Recipe recipe = recipeRepository.findById(recipeId)
-            .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
+        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
 
-    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId)
-            .orElse(null);
-
+    MemberRecipe memberRecipe = memberRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId).orElse(null);
     if (memberRecipe == null) {
-      // 처음 좋아요 누름 → 새로 생성
       memberRecipe = MemberRecipe.builder()
-              .member(member)
-              .recipe(recipe)
-              .isOwner(false)
-              .isLiked(true)
-              .build();
+          .member(member)
+          .recipe(recipe)
+          .isOwner(false)
+          .isLiked(true)
+          .build();
       memberRecipeRepository.save(memberRecipe);
       recipe.setLikeCount(recipe.getLikeCount() + 1);
     } else {
-      // 기존 존재 → 좋아요 토글
       boolean wasLiked = memberRecipe.getIsLiked();
       memberRecipe.toggleLike();
       recipe.setLikeCount(recipe.getLikeCount() + (memberRecipe.getIsLiked() ? 1 : -1));
     }
   }
+
   @Transactional(readOnly = true)
   public List<RecipeDto> getLikedRecipes(Long memberId) {
     List<Recipe> likedRecipes = memberRecipeRepository.findLikedRecipesByMemberId(memberId);
-    return likedRecipes.stream()
-        .map(RecipeDto::from)
-        .collect(Collectors.toList());
+    return likedRecipes.stream().map(RecipeDto::from).collect(Collectors.toList());
   }
 
   public List<Recipe> getPublicRecipes() {
@@ -176,7 +143,6 @@ public class RecipeService {
   public RecipeDto getRecipeFromMemberRecipe(Long memberRecipeId) {
     MemberRecipe mr = memberRecipeRepository.findById(memberRecipeId)
         .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_RECIPE_NOT_FOUND));
-
     return RecipeDto.from(mr.getRecipe());
   }
 
@@ -185,22 +151,17 @@ public class RecipeService {
     MemberRecipe memberRecipe = memberRecipeRepository.findById(memberRecipeId)
         .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_RECIPE_NOT_FOUND));
 
-    // 다른 사람이 요청한 경우 차단
     if (!memberRecipe.getMember().getId().equals(memberId)) {
       throw BaseException.from(ErrorCode.NOT_RECIPE_OWNER);
     }
 
     Recipe recipe = memberRecipe.getRecipe();
-
-    // 좋아요만 누른 경우 → 연결만 삭제
     if (!memberRecipe.getIsOwner()) {
       memberRecipeRepository.delete(memberRecipe);
       return;
     }
 
-    // 소유자인 경우 → 연결 삭제 후 레시피 사용 여부 확인
     memberRecipeRepository.delete(memberRecipe);
-
     long count = memberRecipeRepository.countByRecipeId(recipe.getId());
     if (count == 0) {
       if (recipe.getThumbnailImage() != null) {
@@ -209,9 +170,16 @@ public class RecipeService {
       if (recipe.getSourceImage() != null) {
         s3UploadService.deleteFile(recipe.getSourceImage().getS3Key());
       }
-
       recipeRepository.delete(recipe);
     }
+  }
+
+  @Transactional
+  public RecipeParseResultDto extractTextFromImage(MultipartFile imageFile) {
+    String imageUrl = s3UploadService.uploadAndGenerateKey(imageFile);
+    RecipeParseResultDto result = ocrClient.extractText(imageUrl);
+    result.setSourceImageUrl(imageUrl);
+    return result;
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -174,12 +174,39 @@ public class RecipeService {
     }
   }
 
-  @Transactional
-  public RecipeParseResultDto extractTextFromImage(MultipartFile imageFile) {
-    String imageUrl = s3UploadService.uploadAndGenerateKey(imageFile);
-    RecipeParseResultDto result = ocrClient.extractText(imageUrl);
-    result.setSourceImageUrl(imageUrl);
-    return result;
+  public RecipeDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
+    // 1. 이미지 저장 (S3 + DB)
+    Image image = imageService.saveImage(imageFile);
+
+    // 2. OCR 수행 (imageFile로 Multipart 요청)
+    RecipeParseResultDto dto = ocrClient.extractText(imageFile);
+    dto.setSourceImageUrl(image.getS3Url());
+
+    // 3. 레시피 생성
+    Recipe recipe = createFromOcr(memberId, dto, image);
+    return RecipeDto.from(recipe);
+  }
+
+  public Recipe createFromOcr(Long memberId, RecipeParseResultDto dto, Image image) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+    Recipe recipe = Recipe.of(
+        dto.getTitle(),
+        member.getNickname(),
+        Recipe.RecipeType.PRIVATE,
+        dto.getServings(),
+        dto.getText(),
+        image // 저장된 이미지 그대로 사용
+    );
+
+    recipeRepository.save(recipe);
+    memberRecipeRepository.save(MemberRecipe.of(member, recipe));
+    ingredientService.saveIngredients(dto.getIngredients(), recipe);
+    recipeStepService.saveSteps(dto.getSteps(), recipe);
+    imageService.generateAndSaveThumbnail(recipe.getId());
+
+    return recipe;
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/global/config/AiWebClientConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/AiWebClientConfig.java
@@ -1,0 +1,4 @@
+package sejong.capston.yechef.global.config;
+
+public class AiWebClientConfig {
+}

--- a/yechef/src/main/java/sejong/capston/yechef/global/config/AiWebClientConfig.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/config/AiWebClientConfig.java
@@ -1,4 +1,17 @@
 package sejong.capston.yechef.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
 public class AiWebClientConfig {
+  @Bean
+  public WebClient aiWebClient(@Value("${ai.server.url}") String url) {
+    return WebClient.builder()
+        .baseUrl(url)
+        .build();
+  }
 }
+

--- a/yechef/src/main/resources/application.yml
+++ b/yechef/src/main/resources/application.yml
@@ -63,3 +63,7 @@ cloud:
     credentials:
       access-key: ${AWS_ACCESS_KEY_ID}
       secret-key: ${AWS_SECRET_ACCESS_KEY}
+
+ai:
+  server:
+    url: ${AI_SERVER_URL}


### PR DESCRIPTION
# 이슈
- [AI OCR 기능 세팅 및 레시피 파싱]

# 구현 기능
- WebClient 설정 및 aiWebClient Bean 등록
- OcrClient를 통해 AI 서버에 MultipartFile 기반 OCR 요청 구현 (기존 imageUrl 방식 제거)
- RecipeParseResultDto에 sourceImageUrl 필드 및 전체 생성자 추가
- 이미지 업로드 및 저장 로직을 ImageService.saveImage로 분리
- RecipeService에서 이미지 → OCR → 레시피 생성 전체 흐름 구현
- /ocr/create API 추가 (이미지 업로드 기반 레시피 자동 생성)
- application.yml에 AI 서버 설정값 추가
- WebClient 다중 Bean 충돌 해결을 위한 @Qualifier 적용
