### PR TITLE
[feat] OCR-GPT 기반 이미지 레시피 생성 흐름 개선 및 파일 직접 전송 구조 반영

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -20,7 +20,7 @@ public class OcrClient {
   }
 
 
-  public RecipeParseResultDto extractText(MultipartFile imageFile) {
+  public String extractText(MultipartFile imageFile) {
     MultipartBodyBuilder builder = new MultipartBodyBuilder();
     builder.part("file", imageFile.getResource());
 
@@ -29,8 +29,8 @@ public class OcrClient {
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .bodyValue(builder.build())
         .retrieve()
-        .bodyToMono(RecipeParseResultDto.class)
-        .block();
+        .bodyToMono(String.class)
+        .block();   // raw OCR text
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -26,7 +26,7 @@ public class RecipeController {
 
   private final RecipeService recipeService;
 
-  // ✅ 레시피 저장 (AI에서 받은 OCR 결과 저장)
+  // 레시피 저장 (AI에서 받은 OCR 결과 저장)
   @PostMapping(value = "/{memberId}", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<RecipeDto> createRecipe(
       @Parameter(description = "회원 ID", required = true)

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
+import sejong.capston.yechef.domain.Gpt.service.GptService;
 import sejong.capston.yechef.domain.Image.Image;
 import sejong.capston.yechef.domain.Image.repository.ImageRepository;
 import sejong.capston.yechef.domain.Image.service.ImageService;
@@ -36,6 +37,7 @@ public class RecipeService {
   private final ImageRepository imageRepository;
 
   private final ImageService imageService;
+  private final GptService gptService;
   private final S3UploadService s3UploadService;
   private final IngredientService ingredientService;
   private final RecipeStepService recipeStepService;
@@ -174,18 +176,23 @@ public class RecipeService {
     }
   }
 
+  @Transactional
   public RecipeDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
-    // 1. 이미지 저장 (S3 + DB)
+    // 1. 이미지 저장
     Image image = imageService.saveImage(imageFile);
 
-    // 2. OCR 수행 (imageFile로 Multipart 요청)
-    RecipeParseResultDto dto = ocrClient.extractText(imageFile);
+    // 2. OCR: raw text 추출
+    String rawText = ocrClient.extractText(imageFile);
+
+    // 3. GPT 파싱 요청
+    RecipeParseResultDto dto = gptService.parseRecipe(rawText);
     dto.setSourceImageUrl(image.getS3Url());
 
-    // 3. 레시피 생성
+    // 4. 레시피 생성
     Recipe recipe = createFromOcr(memberId, dto, image);
     return RecipeDto.from(recipe);
   }
+
 
   public Recipe createFromOcr(Long memberId, RecipeParseResultDto dto, Image image) {
     Member member = memberRepository.findById(memberId)


### PR DESCRIPTION
# 이슈
- [이미지 기반 레시피 생성 개선]

# 구현 기능
- GPT 파싱 로직 분리 및 명시적 추가
  - OCR 결과를 바로 RecipeParseResultDto로 변환하지 않고, GPT에게 넘겨 파싱 결과를 받아오도록 구조 변경
  - OCR 결과는 `String rawText`로 받고, 이를 `gptService.parseRecipe(rawText)`에 전달하여 파싱 처리
- 이미지 전송 방식 개선
  - 기존: S3 URL을 AI 서버에 전달
  - 변경: 이미지 파일 자체를 `multipart/form-data` 형식으로 AI 서버에 직접 전송
  - `OcrClient`의 `extractText()` 메서드가 이미지 URL이 아닌 `MultipartFile`을 받도록 수정
  - WebClient가 파일을 직접 전송하고, Flask 서버에서는 `request.files["file"]`로 직접 처리
  - AI 서버의 이미지 다운로드 단계 제거