### PR TITLE
[feat] 퍼블릭 레시피 조회 API 응답 RecipeDto 리스트로 변경

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -69,7 +69,7 @@ public class RecipeController {
 
   // 공개 목록 조회
   @GetMapping("/public")
-  public ResponseEntity<List<Recipe>> getPublicRecipes() {
+  public ResponseEntity<List<RecipeDto>> getPublicRecipes() {
     return ResponseEntity.ok(recipeService.getPublicRecipes());
   }
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeDto.java
@@ -13,6 +13,7 @@ public class RecipeDto {
   private String title;
   private String author;
   private Recipe.RecipeType recipeType;
+  private String text;
   private int likeCount;
   private String thumbnailImageUrl;
   private String sourceImageUrl;
@@ -25,6 +26,7 @@ public class RecipeDto {
         .author(recipe.getAuthor())
         .recipeType(recipe.getRecipeType())
         .likeCount(recipe.getLikeCount())
+        .text(recipe.getText())
         .thumbnailImageUrl(recipe.getThumbnailImage() != null ? recipe.getThumbnailImage().getS3Url() : null)
         .sourceImageUrl(recipe.getSourceImage() != null ? recipe.getSourceImage().getS3Url() : null)
         .build();

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -137,8 +137,12 @@ public class RecipeService {
     return likedRecipes.stream().map(RecipeDto::from).collect(Collectors.toList());
   }
 
-  public List<Recipe> getPublicRecipes() {
-    return recipeRepository.findByRecipeType(Recipe.RecipeType.PUBLIC);
+  public List<RecipeDto> getPublicRecipes() {
+    return recipeRepository
+        .findByRecipeType(Recipe.RecipeType.PUBLIC)
+        .stream()
+        .map(RecipeDto::from)
+        .collect(Collectors.toList());
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
# 이슈
- [퍼블릭 레시피 API 반환 타입 수정]

# 구현 기능
- `RecipeService.getPublicRecipes()` 메서드 수정: 엔티티(`Recipe`) 리스트 대신 `RecipeDto` 리스트 반환  
- `RecipeController.getPublicRecipes()` 반환 타입을 `ResponseEntity<List<RecipeDto>>` 로 변경하고 `produces = application/json` 지정  
- `RecipeDto.from(Recipe)` 매핑 로직 적용:  
  - `id`, `title`, `author`, `recipeType`, `text`, `likeCount`  
  - `thumbnailImageUrl`, `sourceImageUrl` (null 체크 포함)  
