### PR TITLE
[refactor] 이미지 기반 레시피 생성 로직의 반환 타입을 DetailRecipeDto로 통일

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -41,7 +41,7 @@ public class RecipeController {
   }
 
   @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<RecipeDto> createRecipeFromImage(
+  public ResponseEntity<DetailRecipeDto> createRecipeFromImage(
       @RequestParam("memberId") Long memberId,
       @RequestPart("image") MultipartFile imageFile) {
     DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -44,7 +44,7 @@ public class RecipeController {
   public ResponseEntity<RecipeDto> createRecipeFromImage(
       @RequestParam("memberId") Long memberId,
       @RequestPart("image") MultipartFile imageFile) {
-    RecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
+    DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
     return ResponseEntity.ok(result);
   }
 

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -181,7 +181,7 @@ public class RecipeService {
   }
 
   @Transactional
-  public RecipeDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
+  public DetailRecipeDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
     // 1. 이미지 저장
     Image image = imageService.saveImage(imageFile);
 
@@ -194,7 +194,7 @@ public class RecipeService {
 
     // 4. 레시피 생성
     Recipe recipe = createFromOcr(memberId, dto, image);
-    return RecipeDto.from(recipe);
+    return DetailRecipeDto.from(recipe);
   }
 
 


### PR DESCRIPTION
# 이슈
- [이미지 기반 레시피 생성 로직의 반환 타입을 DetailRecipeDto로 통일]

# 구현 기능
- `RecipeService#createRecipeFromImage`의 반환 타입을 `DetailRecipeDto`로 변경
- `RecipeController#createRecipeFromImage`의 응답 타입도 `ResponseEntity<DetailRecipeDto>`로 수정
- 레시피 생성 이후 더 세부적인 정보 제공을 위해 단순 DTO → 상세 DTO로 일괄 변경

