### PR TITLE
[Fix] OCR API 엔드포인트 URI 경로 수정

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -25,7 +25,7 @@ public class OcrClient {
     builder.part("file", imageFile.getResource());
 
     return webClient.post()
-        .uri("/ocr/parse")
+        .uri("/api/ocr")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .bodyValue(builder.build())
         .retrieve()


### PR DESCRIPTION
# 이슈
- [OCR 요청 시 404 에러 발생]

# 구현 기능
- `OcrClient.java`에서 잘못된 API 경로(`/ocr/parse`)를 실제 Flask 서버의 엔드포인트(`/api/ocr`)로 수정
- 변경 전 경로로 인해 404 Not Found 에러 발생 확인
- Flask 서버 로그 및 `ocr_app.py`의 실제 엔드포인트 기준으로 수정