### PR TITLE
feat: s3Url 필드 @Lob 및 @Column(length = 2048) 설정으로 URL 길이 확장 대응

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Image/Image.java
@@ -15,6 +15,8 @@ public class Image {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Lob
+  @Column(length = 2048)
   private String s3Url;
   private String s3Key; // ← 키는 동적으로 외부에서 생성해서 주입해야 함
 


### PR DESCRIPTION
# 이슈
- [S3 URL 필드 저장 길이 초과 문제 해결]

# 구현 기능
- `Image` 엔티티의 `s3Url` 필드에 `@Lob` 및 `@Column(length = 2048)` 어노테이션 추가
- S3 URL이 길어져도 `DataTruncation` 예외 발생하지 않도록 대응
- 기존 `VARCHAR(255)` 제한을 벗어나 `TEXT` 타입으로 저장 가능하도록 처리

# 기타
- `s3Key` 필드는 외부에서 직접 생성되므로 별도 변경 없음
