### PR TITLE
feat: OCR 기반 레시피 생성 기능 개선 및 결과 반환 구조 변경

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -1,7 +1,11 @@
 package sejong.capston.yechef.domain.Recipe.ai;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Component;
@@ -20,17 +24,40 @@ public class OcrClient {
   }
 
 
+//  public String extractText(MultipartFile imageFile) {
+//    MultipartBodyBuilder builder = new MultipartBodyBuilder();
+//    builder.part("image", imageFile.getResource());
+//
+//    return webClient.post()
+//        .uri("/api/ocr")
+//        .contentType(MediaType.MULTIPART_FORM_DATA)
+//        .bodyValue(builder.build())
+//        .retrieve()
+//        .bodyToMono(String.class)
+//        .block();   // raw OCR text
+//  }
+
   public String extractText(MultipartFile imageFile) {
     MultipartBodyBuilder builder = new MultipartBodyBuilder();
-    builder.part("image", imageFile.getResource());
+    try {
+      builder.part("image", new ByteArrayResource(imageFile.getBytes()) {
+        @Override
+        public String getFilename() {
+          return imageFile.getOriginalFilename();
+        }
+      });
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read image file", e);
+    }
 
     return webClient.post()
         .uri("/api/ocr")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .bodyValue(builder.build())
         .retrieve()
-        .bodyToMono(String.class)
-        .block();   // raw OCR text
+        .bodyToMono(new ParameterizedTypeReference<Map<String, List<String>>>() {})
+        .map(map -> String.join("\n", map.getOrDefault("texts", List.of())))
+        .block();
   }
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.dto.DetailRecipeDto;
+import sejong.capston.yechef.domain.Recipe.dto.OcrRecipeResultDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.service.RecipeService;
 
@@ -40,13 +41,22 @@ public class RecipeController {
         .body(result);
   }
 
-  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<DetailRecipeDto> createRecipeFromImage(
-      @RequestParam("memberId") Long memberId,
-      @RequestPart("image") MultipartFile imageFile) {
-    DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
-    return ResponseEntity.ok(result);
-  }
+//  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//  public ResponseEntity<DetailRecipeDto> createRecipeFromImage(
+//      @RequestParam("memberId") Long memberId,
+//      @RequestPart("image") MultipartFile imageFile) {
+//    DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
+//    return ResponseEntity.ok(result);
+//  }
+@PostMapping("/ocr/create")
+public ResponseEntity<OcrRecipeResultDto> createRecipeFromImage(
+    @RequestParam("memberId") Long memberId,
+    @RequestPart("image") MultipartFile imageFile) {
+
+  OcrRecipeResultDto result = recipeService.createRecipeFromImage(memberId, imageFile);
+
+  return ResponseEntity.ok(result);
+}
 
   // 상세 조회
   @GetMapping("/{recipeId}")

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/OcrRecipeResultDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/OcrRecipeResultDto.java
@@ -1,0 +1,19 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import sejong.capston.yechef.domain.Recipe.Recipe;
+
+@Getter
+@Builder
+public class OcrRecipeResultDto {
+  private DetailRecipeDto recipe;
+  private String rawText;
+
+  public static OcrRecipeResultDto from(Recipe recipe, String rawText) {
+    return OcrRecipeResultDto.builder()
+        .recipe(DetailRecipeDto.from(recipe))
+        .rawText(rawText)
+        .build();
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -20,6 +20,7 @@ import sejong.capston.yechef.domain.MemberRecipe.repository.MemberRecipeReposito
 import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.ai.OcrClient;
 import sejong.capston.yechef.domain.Recipe.dto.DetailRecipeDto;
+import sejong.capston.yechef.domain.Recipe.dto.OcrRecipeResultDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeStepDto;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
@@ -182,7 +183,7 @@ public class RecipeService {
   }
 
   @Transactional
-  public DetailRecipeDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
+  public OcrRecipeResultDto createRecipeFromImage(Long memberId, MultipartFile imageFile) {
     // 1. 이미지 저장
     Image image = imageService.saveImage(imageFile);
 
@@ -195,7 +196,7 @@ public class RecipeService {
 
     // 4. 레시피 생성
     Recipe recipe = createFromOcr(memberId, dto, image);
-    return DetailRecipeDto.from(recipe);
+    return OcrRecipeResultDto.from(recipe, rawText);
   }
 
 


### PR DESCRIPTION
# 이슈  
- [OCR 레시피 생성 응답 개선]  

# 구현 기능  
- OcrClient: WebClient 응답 형식을 Map 기반으로 파싱하도록 수정  
- RecipeService: OCR 원문(`rawText`)과 생성 레시피 함께 리턴  
- RecipeController: 리턴 DTO를 `OcrRecipeResultDto`로 변경  
- OcrRecipeResultDto: OCR 결과 포함된 응답 DTO 새로 생성  
