### PR TITLE
[feat] GPT 파싱 후 레시피 저장 시 재료·단계 저장 로직 및 addIngredient/addStep 헬퍼 메서드 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
@@ -48,7 +48,7 @@ public class GptService {
             …
           ],
           "steps": [
-            { "stepNumber": 1, "action": "<단일 행위>", "description": "<상세 설명>" },
+            { "stepNumber": 1, "action": "<단일 행위>", "ingredients": <단계에쓰인재료들>, "description": "<상세 설명>" },
             …
           ]
         }
@@ -60,6 +60,8 @@ public class GptService {
         4. 출력은 반드시 JSON만 포함되도록 하세요. 설명이나 마크다운 블록 없이 반환합니다.
         5. steps 배열의 각 항목에는 "stepNumber" 필드가 반드시 있어야 하며, 그 값은 **1부터 시작해 1씩 순차 증가**해야 합니다. 
         절대로 0이거나 중복되면 안 됩니다. (예: 1, 2, 3, …)
+        6. steps 내부 키 "ingredients": 해당 레시피 단계에 설명(description)에 언급된 재료명만 한국어로 배열에 담아 반환  
+             (수식어 제거, "물" 제외)
         """;
 
         // GPT 호출
@@ -95,9 +97,17 @@ public class GptService {
             List<RecipeStepDetailDto> steps = new ArrayList<>();
             int index = 1;
             for (JsonNode stepNode : root.path("steps")) {
+
+                // 단계별 재료(문자열 리스트) 추출
+                List<String> stepIngredients = new ArrayList<>();
+                for (JsonNode ing : stepNode.path("ingredients")) {
+                    stepIngredients.add(ing.asText());
+                }
+
                 steps.add(RecipeStepDetailDto.builder()
-                        .stepNumber(stepNode.path("order").asInt(index++))
+                        .stepNumber(stepNode.path("stepNumber").asInt(index++))
                         .action(stepNode.path("action").asText(""))
+                        .ingredients(stepIngredients)
                         .description(stepNode.path("description").asText(""))
                         .build()
                 );

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Gpt/service/GptService.java
@@ -123,15 +123,15 @@ public class GptService {
 
     public RecipeStepDetailDto parseRecipeSteps(Long recipeId, int stepNumber) {
         String systemPrompt = """
-      You are an AI that converts a single Korean recipe step description into a JSON object.
-      ◆ Input: a Korean sentence describing one cooking step.
-      ◆ Output: pure JSON only, with exactly these fields:
-        - "stepNumber": the original step number (integer)
-        - "action": a short English verb phrase describing the action
-        - "ingredients": a JSON array of English ingredient names mentioned in the description,
-          with adjectives removed and excluding "water"
-      No other keys or commentary.
-      """;
+        당신은 단일 한국어 조리 단계 설명을 받아 JSON 객체로 변환하는 AI입니다.
+        ◆ 입력: 한국어로 된 하나의 조리 단계 설명 문장
+        ◆ 출력: 순수 JSON만 반환하며, 반드시 아래 세 가지 필드만 포함해야 합니다.
+          - "stepNumber": 원래 단계 번호 (정수)
+          - "action": 해당 조리 동작을 짧은 한국어 동사구(예: "썰기", "볶기")로 표현
+          - "ingredients": 설명에 언급된 재료명만 한국어로 배열에 담아 반환  
+             (수식어 제거, "물" 제외)
+        그 외의 키, 주석, 설명 문구는 절대 포함하지 마세요!
+        """;
 
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
@@ -169,15 +169,16 @@ public class GptService {
 
     public String parseRecipeStepsTest(Long recipeId, int stepNumber) {
         String systemPrompt = """
-        You are an AI that converts a single Korean recipe step description into a JSON object.
-        ◆ Input: a Korean sentence describing one cooking step.
-        ◆ Output: pure JSON only, with exactly these fields:
-            - "stepNumber": the original step number (integer)
-            - "action": a short English verb phrase describing the action
-            - "ingredients": a JSON array of English ingredient names mentioned in the description,
-              with adjectives removed and excluding "water"
-          No other keys or commentary.
-          """;
+        당신은 단일 한국어 조리 단계 설명을 받아 JSON 객체로 변환하는 AI입니다.
+        ◆ 입력: 한국어로 된 하나의 조리 단계 설명 문장
+        ◆ 출력: 순수 JSON만 반환하며, 반드시 아래 세 가지 필드만 포함해야 합니다.
+          - "stepNumber": 원래 단계 번호 (정수)
+          - "action": 해당 조리 동작을 짧은 한국어 동사구(예: "썰기", "볶기")로 표현
+          - "ingredients": 설명에 언급된 재료명만 한국어로 배열에 담아 반환  
+             (수식어 제거, "물" 제외)
+        그 외의 키, 주석, 설명 문구는 절대 포함하지 마세요!
+        """;
+
 
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Ingredient/Ingredient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Ingredient/Ingredient.java
@@ -48,6 +48,18 @@ public class Ingredient extends BaseEntity {
 
     public static Ingredient of(
             String originalName,
+            String originalAmount,
+            Recipe recipe
+    ) {
+        return Ingredient.builder()
+                .originalName(originalName)
+                .originalAmount(originalAmount)
+                .recipe(recipe)
+                .build();
+    }
+
+    public static Ingredient of(
+            String originalName,
             String alternativeName,
             String originalAmount,
             String oneServingAmount,

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/Recipe.java
@@ -65,6 +65,16 @@ public class Recipe extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Image sourceImage;
 
+    public void addIngredient(Ingredient ing) {
+        ingredients.add(ing);
+        ing.setRecipe(this);
+    }
+
+    public void addStep(RecipeStep step) {
+        recipeSteps.add(step);
+        step.setRecipe(this);
+    }
+
     @Builder
     public Recipe(
             Long id,

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -7,11 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import sejong.capston.yechef.domain.Gpt.dto.IngredientDto;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Gpt.service.GptService;
 import sejong.capston.yechef.domain.Image.Image;
 import sejong.capston.yechef.domain.Image.repository.ImageRepository;
 import sejong.capston.yechef.domain.Image.service.ImageService;
+import sejong.capston.yechef.domain.Ingredient.Ingredient;
 import sejong.capston.yechef.domain.Ingredient.service.IngredientService;
 import sejong.capston.yechef.domain.Member.Member;
 import sejong.capston.yechef.domain.Member.repository.MemberRepository;
@@ -24,6 +26,8 @@ import sejong.capston.yechef.domain.Recipe.dto.OcrRecipeResultDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeStepDto;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
+import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
+import sejong.capston.yechef.domain.RecipeSteps.dto.RecipeStepDetailDto;
 import sejong.capston.yechef.domain.RecipeSteps.service.RecipeStepService;
 import sejong.capston.yechef.global.exception.BaseException;
 import sejong.capston.yechef.global.exception.error.ErrorCode;
@@ -212,6 +216,17 @@ public class RecipeService {
         dto.getText(),
         image // 저장된 이미지 그대로 사용
     );
+
+    // DTO → 엔티티 변환 시
+    for (IngredientDto ingredientDto : dto.getIngredients()) {
+      Ingredient ing = Ingredient.of(ingredientDto.getName(), ingredientDto.getQuantity(), recipe);
+      recipe.addIngredient(ing);
+    }
+    for (RecipeStepDetailDto stepDto : dto.getSteps()) {
+      RecipeStep step = RecipeStep.of(stepDto.getStepNumber(), stepDto.getAction(), stepDto.getIngredients(),
+              stepDto.getDescription(), recipe);
+      recipe.addStep(step);
+    }
 
     recipeRepository.save(recipe);
     memberRecipeRepository.save(MemberRecipe.of(member, recipe));

--- a/yechef/src/main/java/sejong/capston/yechef/domain/RecipeSteps/dto/RecipeStepDetailDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/RecipeSteps/dto/RecipeStepDetailDto.java
@@ -16,16 +16,12 @@ public class RecipeStepDetailDto {
     private String description; // “떡 300g을 먹기 좋은 크기로 썬다”
     private List<String> ingredients;
 
-    public RecipeStepDetailDto(int stepNumber, String action, String description) {
-        this.stepNumber = stepNumber;
-        this.action = action;
-        this.description = description;
-    }
-
     public static RecipeStepDetailDto from(RecipeStep step) {
         return RecipeStepDetailDto.builder()
                 .stepNumber(step.getStepNumber())
                 .description(step.getDescription())
+                .action(step.getAction())
+                .ingredients(step.getIngredients())
                 .build();
     }
 


### PR DESCRIPTION
# 이슈
- #10 
- #6 

# 구현 기능
- `RecipeService`  
  - GPT 파싱 결과를 기반으로 Recipe 엔티티에 재료(`ingredients`) 및 단계(`recipeSteps`) 저장 로직 추가  
  - `addIngredient(Ingredient)` / `addStep(RecipeStep)` 헬퍼 메서드 도입으로 양방향 연관관계 편의성 개선  
- `GptService`  
  - `steps` 내부 JSON `"ingredients"` 필드 파싱 기능 구현  
  - `RecipeParseResultDto` 및 `RecipeStepDetailDto` 빌더 로직 보완  
- `OcrClient` & `RecipeController`  
  - WebClient multipart 전송 시 `BodyInserters.fromMultipartData(...)` 적용  
  - `/api/recipes/ocr/create` 엔드포인트에 `consumes: MULTIPART_FORM_DATA` 설정 추가  

# 작업 시간
