### PR TITLE
[fix] RecipeController OCR 이미지 업로드 및 OcrClient WebClient multipart 처리 개선

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/ai/OcrClient.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 
@@ -53,7 +54,7 @@ public class OcrClient {
     return webClient.post()
         .uri("/api/ocr")
         .contentType(MediaType.MULTIPART_FORM_DATA)
-        .bodyValue(builder.build())
+        .body(BodyInserters.fromMultipartData(builder.build()))
         .retrieve()
         .bodyToMono(new ParameterizedTypeReference<Map<String, List<String>>>() {})
         .map(map -> String.join("\n", map.getOrDefault("texts", List.of())))

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -48,7 +48,7 @@ public class RecipeController {
 //    DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
 //    return ResponseEntity.ok(result);
 //  }
-@PostMapping("/ocr/create")
+@PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 public ResponseEntity<OcrRecipeResultDto> createRecipeFromImage(
     @RequestParam("memberId") Long memberId,
     @RequestPart("image") MultipartFile imageFile) {


### PR DESCRIPTION
# 이슈
- #6 

# 구현 기능
- **RecipeController**  
  - `/api/recipes/ocr/create` 핸들러의 `@PostMapping`에 `consumes = MediaType.MULTIPART_FORM_DATA_VALUE` 설정을 추가하여 이미지 업로드 요청을 올바르게 수신·파싱하도록 수정  
- **OcrClient**  
  - 기존 `bodyValue(builder.build())` 호출을 `body(BodyInserters.fromMultipartData(builder.build()))`로 변경하여 `MultipartBodyBuilder`로 구성한 이미지 데이터를 WebClient가 정확히 전송하도록 개선  

# 작업 시간
