### PR TITLE
[feat] GPT 프롬프트에 SUBSTITUTE 대체 가능성 판단 및 안내 문구 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeProgressService.java
@@ -137,7 +137,9 @@ public class RecipeProgressService {
     - "PREVIOUS": 이전 단계로 이동
     - "REPEAT": 다시 설명
     - "EXPLAIN: <설명>": 보조 설명
-    - "SUBSTITUTE: <기존재료> → <대체재료>": 재료 변경
+    - "SUBSTITUTE: <기존재료> → <대체재료>": 요청된 대체가 가능한지 먼저 판단하고,
+       • 가능하면 변경된 조리 과정을 안내
+       • 불가능하면 이유를 설명
     """.formatted(stepDescription, userInput, formattedIngredients);
   }
 }


### PR DESCRIPTION
# 이슈
- [# GPT 프롬프트에 SUBSTITUTE 대체 판단 안내 문구 추가]

# 구현 기능
- `RecipeProgressService.buildPrompt` 내 SUBSTITUTE 명령 처리 가이드 문구 보완  
  - 요청된 대체 가능성 판단 및 안내 로직 설명 추가