### PR TITLE
feat(recipe): 양 스케일링 기능 및 targetServings API 추가

### DIFF
--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/controller/RecipeController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
-import sejong.capston.yechef.domain.Recipe.Recipe;
 import sejong.capston.yechef.domain.Recipe.dto.DetailRecipeDto;
 import sejong.capston.yechef.domain.Recipe.dto.OcrRecipeResultDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
@@ -41,31 +40,40 @@ public class RecipeController {
         .body(result);
   }
 
-//  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  //  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 //  public ResponseEntity<DetailRecipeDto> createRecipeFromImage(
 //      @RequestParam("memberId") Long memberId,
 //      @RequestPart("image") MultipartFile imageFile) {
 //    DetailRecipeDto result = recipeService.createRecipeFromImage(memberId, imageFile);
 //    return ResponseEntity.ok(result);
 //  }
-@PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-public ResponseEntity<OcrRecipeResultDto> createRecipeFromImage(
-    @RequestParam("memberId") Long memberId,
-    @RequestPart("image") MultipartFile imageFile) {
+  @PostMapping(value = "/ocr/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<OcrRecipeResultDto> createRecipeFromImage(
+      @RequestParam("memberId") Long memberId,
+      @RequestPart("image") MultipartFile imageFile) {
 
-  OcrRecipeResultDto result = recipeService.createRecipeFromImage(memberId, imageFile);
+    OcrRecipeResultDto result = recipeService.createRecipeFromImage(memberId, imageFile);
 
-  return ResponseEntity.ok(result);
-}
+    return ResponseEntity.ok(result);
+  }
 
   // 상세 조회
   @GetMapping("/{recipeId}")
   public ResponseEntity<DetailRecipeDto> getRecipe(
-      @Parameter(description = "조회할 레시피 ID", required = true)
-      @PathVariable("recipeId") Long recipeId
+      @PathVariable("recipeId") Long recipeId,
+      @RequestParam(name = "targetServings", required = false) Integer targetServings
   ) {
-    return ResponseEntity.ok(recipeService.getRecipe(recipeId));
+    DetailRecipeDto dto;
+    if (targetServings != null) {
+      // targetServings이 지정됐으면 스케일된 버전
+      dto = recipeService.getScaledRecipe(recipeId, targetServings);
+    } else {
+      // 지정이 없으면 기존 로직
+      dto = recipeService.getRecipe(recipeId);
+    }
+    return ResponseEntity.ok(dto);
   }
+
 
   // 삭제
   @DeleteMapping("/members/{memberId}/recipes/{recipeId}")

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/DetailRecipeDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/DetailRecipeDto.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 @Getter
 @Builder
 public class DetailRecipeDto {
+
   private Long id;
   private String title;
   private int likeCount;
@@ -26,7 +27,7 @@ public class DetailRecipeDto {
   private Recipe.RecipeType recipeType;
   private boolean isUpdated;
 
-  private List<IngredientDto> ingredients;
+  private List<RecipeIngredientDto> ingredients;
   private List<RecipeStepDto> recipeSteps;
 
   private ImageDto thumbnailImage;
@@ -45,9 +46,14 @@ public class DetailRecipeDto {
         .isUpdated(recipe.isUpdated())
         .ingredients(recipe.getIngredients() != null
             ? recipe.getIngredients().stream()
-            .map(IngredientDto::from)
+            .map(ing -> RecipeIngredientDto.of(
+                ing.getOriginalName(),
+                ing.getOriginalAmount(),
+                ing.getOriginalAmount()   // 원본 조회 시엔 scaled=original
+            ))
             .collect(Collectors.toList())
             : null)
+
         .recipeSteps(recipe.getRecipeSteps() != null
             ? recipe.getRecipeSteps().stream()
             .map(RecipeStepDto::from)
@@ -61,7 +67,6 @@ public class DetailRecipeDto {
             : null)
         .build();
   }
-
 
 
 }

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeIngredientDto.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/dto/RecipeIngredientDto.java
@@ -1,0 +1,21 @@
+package sejong.capston.yechef.domain.Recipe.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecipeIngredientDto {
+
+  private String name;
+  private String originalAmount;
+  private String scaledAmount;
+
+  public static RecipeIngredientDto of(String name, String originalAmount, String scaledAmount) {
+    return RecipeIngredientDto.builder()
+        .name(name)
+        .originalAmount(originalAmount)
+        .scaledAmount(scaledAmount)
+        .build();
+  }
+}

--- a/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
+++ b/yechef/src/main/java/sejong/capston/yechef/domain/Recipe/service/RecipeService.java
@@ -1,14 +1,20 @@
 package sejong.capston.yechef.domain.Recipe.service;
 
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import sejong.capston.yechef.domain.Gpt.dto.IngredientDto;
 import sejong.capston.yechef.domain.Gpt.dto.RecipeParseResultDto;
 import sejong.capston.yechef.domain.Gpt.service.GptService;
+import sejong.capston.yechef.domain.Image.Dto.ImageDto;
 import sejong.capston.yechef.domain.Image.Image;
 import sejong.capston.yechef.domain.Image.repository.ImageRepository;
 import sejong.capston.yechef.domain.Image.service.ImageService;
@@ -23,6 +29,8 @@ import sejong.capston.yechef.domain.Recipe.ai.OcrClient;
 import sejong.capston.yechef.domain.Recipe.dto.DetailRecipeDto;
 import sejong.capston.yechef.domain.Recipe.dto.OcrRecipeResultDto;
 import sejong.capston.yechef.domain.Recipe.dto.RecipeDto;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeIngredientDto;
+import sejong.capston.yechef.domain.Recipe.dto.RecipeStepDto;
 import sejong.capston.yechef.domain.Recipe.repository.RecipeRepository;
 import sejong.capston.yechef.domain.RecipeSteps.RecipeStep;
 import sejong.capston.yechef.domain.RecipeSteps.service.RecipeStepService;
@@ -240,6 +248,110 @@ public class RecipeService {
     imageService.generateAndSaveThumbnail(recipe.getId());
 
     return recipe;
+  }
+
+  public DetailRecipeDto getScaledRecipe(Long recipeId, int targetServings) {
+    Recipe recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(() -> BaseException.from(ErrorCode.RECIPE_NOT_EXIST));
+
+    double ratio = (double) targetServings / recipe.getServings();
+    if (targetServings < 1 || targetServings > 10) {
+      throw BaseException.from(ErrorCode.RECIPE_INVALID_SERVINGS);
+    }
+
+    List<RecipeIngredientDto> scaledIngs = recipe.getIngredients().stream()
+        .map(ing -> {
+          String scaled = scaleAmount(ing.getOriginalAmount(), ratio);
+          return RecipeIngredientDto.of(
+              ing.getOriginalName(),
+              ing.getOriginalAmount(),
+              scaled
+          );
+        })
+        .collect(Collectors.toList());
+
+    List<RecipeStepDto> steps = recipe.getRecipeSteps().stream()
+        .map(step -> {
+          String scaledDesc = scaleAllNumbers(step.getDescription(), ratio);
+          return RecipeStepDto.builder()
+              .stepNumber(step.getStepNumber())
+              .action(step.getAction())
+              .ingredients(step.getIngredients())
+              .description(scaledDesc)
+              .build();
+        })
+        .collect(Collectors.toList());
+
+    return DetailRecipeDto.builder()
+        .id(recipe.getId())
+        .title(recipe.getTitle())
+        .likeCount(recipe.getLikeCount())
+        .author(recipe.getAuthor())
+        .ranking(recipe.getRanking())
+        .servings(targetServings)
+        .text(recipe.getText())
+        .recipeType(recipe.getRecipeType())
+        .isUpdated(recipe.isUpdated())
+        .ingredients(scaledIngs)
+        .recipeSteps(steps)
+        .thumbnailImage(ImageDto.from(recipe.getThumbnailImage()))
+        .sourceImage(ImageDto.from(recipe.getSourceImage()))
+        .build();
+  }
+
+  private String scaleAmount(String original, double ratio) {
+    Matcher m = Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$").matcher(original);
+    if (!m.matches()) {
+      return original;
+    }
+    BigDecimal value = new BigDecimal(m.group(1))
+        .multiply(BigDecimal.valueOf(ratio))
+        .setScale(2, RoundingMode.HALF_UP);
+    String num = value.stripTrailingZeros().toPlainString();
+    return num + m.group(2);
+  }
+
+  private String scaleAllNumbers(String text, double ratio) {
+    Pattern numberPattern = Pattern.compile("(\\d+(?:\\.\\d+)?)");
+    Matcher m = numberPattern.matcher(text);
+    StringBuffer sb = new StringBuffer();
+
+    while (m.find()) {
+      String numStr = m.group(1);
+      int posAfterNum = m.end(1);
+
+      // 숫자 다음에 오는 공백을 모두 건너뛴 뒤 실제 문자를 검사
+      int idx = posAfterNum;
+      while (idx < text.length() && Character.isWhitespace(text.charAt(idx))) {
+        idx++;
+      }
+
+      boolean isTimeUnit = false;
+      if (idx < text.length()) {
+        char c = text.charAt(idx);
+        if (c == '분' || c == '초') {
+          isTimeUnit = true;
+        } else if (text.startsWith("시간", idx)) {
+          isTimeUnit = true;
+        }
+      }
+
+      String replacement;
+      if (isTimeUnit) {
+        // 시간 단위 숫자: 변경 없이 그대로
+        replacement = numStr;
+      } else {
+        // 재료량 등은 스케일 적용
+        BigDecimal scaled = new BigDecimal(numStr)
+            .multiply(BigDecimal.valueOf(ratio))
+            .setScale(2, RoundingMode.HALF_UP);
+        replacement = scaled.stripTrailingZeros().toPlainString();
+      }
+
+      m.appendReplacement(sb, replacement);
+    }
+    m.appendTail(sb);
+    return sb.toString();
   }
 
 

--- a/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
+++ b/yechef/src/main/java/sejong/capston/yechef/global/exception/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     NO_RECIPE_INFO_OF_LIKE("RCP-0002", "레시피 좋아요 정보가 없습니다.", ErrorDisplayType.POPUP),
     NOT_EXIST_THIS_STEP("RCP-0003", "레시피 해당 단계가 존재하지 않습니다.", ErrorDisplayType.POPUP),
     RECIPE_SAVE_FAILED("RCP-0004", "레시피 저장 실패", ErrorDisplayType.POPUP),
+    RECIPE_INVALID_SERVINGS("RCP-0005", "인분 수는 1 이상 10 이하로만 설정 가능합니다.", ErrorDisplayType.POPUP),
 
     // memberRecipe
     MEMBER_RECIPE_NOT_FOUND("MRP-0000", "멤버레시피가 존재하지 않습니다.", ErrorDisplayType.POPUP),


### PR DESCRIPTION
# 이슈
- [양 스케일링 기능 및 targetServings API 추가]

# 구현 기능
- RecipeIngredientDto 추가 및 DetailRecipeDto 수정
- getScaledRecipe 메서드 구현 (수량 스케일링 유틸, 인분 제한 ErrorCode 등록)
- RecipeController에 `targetServings` 파라미터 처리 로직 추가
